### PR TITLE
bug fix assign a full dictionary (#6)

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -34,16 +34,16 @@ from .taipyimage import TaipyImage
 from .types import WsType
 from .utils import (
     Singleton,
+    TaipyBase,
+    TaipyContent,
+    TaipyContentImage,
+    TaipyData,
+    TaipyLov,
+    TaipyLovValue,
     _get_non_existent_file_path,
     _is_in_notebook,
     _MapDictionary,
     attrsetter,
-    TaipyBase,
-    TaipyData,
-    TaipyLov,
-    TaipyLovValue,
-    TaipyContent,
-    TaipyContentImage,
     get_client_var_name,
 )
 from .utils._adapter import _Adapter
@@ -198,7 +198,7 @@ class Gui(object, metaclass=Singleton):
         def __getter(elt: Gui) -> t.Any:
             value = getattr(elt._get_data_scope(), name)
             if isinstance(value, _MapDictionary):
-                return _MapDictionary(value._dict, lambda s, v: elt.__update_var(name + "." + s, v))
+                return _MapDictionary(value._dict, lambda s, v: elt.__update_var(f"{name}.{s}", v))
             else:
                 return value
 

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -34,16 +34,16 @@ from .taipyimage import TaipyImage
 from .types import WsType
 from .utils import (
     Singleton,
-    TaipyBase,
-    TaipyContent,
-    TaipyContentImage,
-    TaipyData,
-    TaipyLov,
-    TaipyLovValue,
     _get_non_existent_file_path,
     _is_in_notebook,
     _MapDictionary,
     attrsetter,
+    TaipyBase,
+    TaipyData,
+    TaipyLov,
+    TaipyLovValue,
+    TaipyContent,
+    TaipyContentImage,
     get_client_var_name,
 )
 from .utils._adapter import _Adapter

--- a/taipy/gui/utils/MapDictionary.py
+++ b/taipy/gui/utils/MapDictionary.py
@@ -11,11 +11,8 @@ class _MapDictionary(object):
 
     local_vars = ("_dict", "_update_var")
 
-    def __init__(self, dict_import, app_update_var=None):
-        # Verify if dict_import is a dictionary
-        if not isinstance(dict_import, dict):
-            raise TypeError("should have a dict")
-        self._dict: dict = dict_import
+    def __init__(self, dict_import: dict, app_update_var=None):
+        self._dict = dict_import
         # Bind app update var function
         self._update_var = app_update_var
 
@@ -74,7 +71,7 @@ class _MapDictionary(object):
     def items(self):
         return self._dict.items()
 
-    def get(self, key: t.Any, value: None) -> t.Union[t.Any, None]:
+    def get(self, key: t.Any, value: t.Union[None, str] = None) -> t.Union[t.Any, None]:
         return self._dict.get(key, value)
 
     def clear(self) -> None:

--- a/taipy/gui/utils/MapDictionary.py
+++ b/taipy/gui/utils/MapDictionary.py
@@ -37,7 +37,8 @@ class _MapDictionary(object):
     def __setitem__(self, key, value):
         if self._update_var:
             self._update_var(key, value)
-        self._dict.__setitem__(key, value)
+        else:
+            self._dict.__setitem__(key, value)
 
     def __delitem__(self, key):
         self._dict.__delitem__(key)

--- a/taipy/gui/utils/MapDictionary.py
+++ b/taipy/gui/utils/MapDictionary.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import typing as t
+
+
 class _MapDictionary(object):
     """
     Provide class binding, can utilize getattr, setattr functionality
@@ -7,12 +12,12 @@ class _MapDictionary(object):
     local_vars = ("_dict", "_update_var")
 
     def __init__(self, dict_import, app_update_var=None):
-        self._dict = dict_import
-        # Bind app update var function
-        self._update_var = app_update_var
         # Verify if dict_import is a dictionary
         if not isinstance(dict_import, dict):
             raise TypeError("should have a dict")
+        self._dict: dict = dict_import
+        # Bind app update var function
+        self._update_var = app_update_var
 
     def __len__(self):
         return self._dict.__len__()
@@ -24,7 +29,7 @@ class _MapDictionary(object):
         value = self._dict.__getitem__(key)
         if isinstance(value, dict):
             if self._update_var:
-                return _MapDictionary(value, lambda s, v: self._update_var(key + "." + s, v))
+                return _MapDictionary(value, lambda s, v: self._update_var(f"{key}.{s}", v))
             else:
                 return _MapDictionary(value)
         return value
@@ -32,8 +37,7 @@ class _MapDictionary(object):
     def __setitem__(self, key, value):
         if self._update_var:
             self._update_var(key, value)
-        else:
-            self._dict.__setitem__(key, value)
+        self._dict.__setitem__(key, value)
 
     def __delitem__(self, key):
         self._dict.__delitem__(key)
@@ -69,23 +73,26 @@ class _MapDictionary(object):
     def items(self):
         return self._dict.items()
 
-    def get(self):
-        return self._dict.get()
+    def get(self, key: t.Any, value: None) -> t.Union[t.Any, None]:
+        return self._dict.get(key, value)
 
-    def clear(self):
-        return self._dict.clear()
+    def clear(self) -> None:
+        self._dict.clear()
 
-    def setdefault(self, key, value=None):
+    def setdefault(self, key, value=None) -> t.Union[t.Any, None]:
         return self._dict.setdefault(key, value)
 
-    def pop(self, key, default=None):
+    def pop(self, key, default=None) -> t.Any:
         return self._dict.pop(key, default)
 
-    def popitem(self):
+    def popitem(self) -> tuple:
         return self._dict.popitem()
 
-    def copy(self):
+    def copy(self) -> _MapDictionary:
         return _MapDictionary(self._dict.copy(), self._update_var)
 
-    def update(self):
-        return self._dict.update()
+    def update(self, d: dict) -> None:
+        current_keys = self.keys()
+        for k, v in d.items():
+            if k not in current_keys or self[k] != v:
+                self.__setitem__(k, v)

--- a/taipy/gui/utils/MapDictionary.py
+++ b/taipy/gui/utils/MapDictionary.py
@@ -71,8 +71,8 @@ class _MapDictionary(object):
     def items(self):
         return self._dict.items()
 
-    def get(self, key: t.Any, value: t.Union[None, str] = None) -> t.Union[t.Any, None]:
-        return self._dict.get(key, value)
+    def get(self, key: t.Any, default_value: t.Optional[str] = None) -> t.Union[t.Any, None]:
+        return self._dict.get(key, default_value)
 
     def clear(self) -> None:
         self._dict.clear()

--- a/tests/taipy/gui/gui_specific/test_mapdict.py
+++ b/tests/taipy/gui/gui_specific/test_mapdict.py
@@ -69,3 +69,26 @@ def test_mapdict_update():
     assert update_values[1] == 3
     print("")
     pass
+
+def test_mapdict_update_full_dictionary_1():
+    values = {"a": 1, "b": 2}
+    update_values = {"a": 3, "b": 5}
+    md = _MapDictionary(values)
+    assert md["a"] == 1
+    assert md["b"] == 2
+    md.update(update_values)
+    assert md["a"] == 3
+    assert md["b"] == 5
+
+def test_mapdict_update_full_dictionary_2():
+    temp_values = {}
+    def update(k, v):
+        temp_values[k] = v
+    values = {"a": 1, "b": 2}
+    update_values = {"a": 3, "b": 5}
+    md = _MapDictionary(values, update)
+    assert md["a"] == 1
+    assert md["b"] == 2
+    md.update(update_values)
+    assert temp_values["a"] == 3
+    assert temp_values["b"] == 5


### PR DESCRIPTION
Solve bug #6

Instead of assignment (which is a real challenge in python to implement), i opted for the update function similar to python dict. below is the example code

```
from taipy.gui import Gui

d = { "v1": 0, "v2": 1}

def on_change(gui, var, val):
    if var == "d.v2":
        d = { "v1": 2*val, "v2": val}
        gui.d.update(d)
  
Gui(page="""
Value: <|{d.v1}|>

Slider: <|{d.v2}|slider|>
""").run()
```