### PR TITLE
bug fix libmagic optional (#17)

### DIFF
--- a/.github/workflows/setuptools.yml
+++ b/.github/workflows/setuptools.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install Taipy without dependencies
         run: |
           pip install .
-          rm -r taipy gui  # Removal of Taipy code to ensure the use of the installed package
-
+          rm -r taipy  # Removal of Taipy code to ensure the use of the installed package
           pip install pytest pytest-mock
           pytest
 

--- a/.github/workflows/setuptools.yml
+++ b/.github/workflows/setuptools.yml
@@ -9,13 +9,18 @@ on:
 jobs:
   standard-packages:
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-versions: ['3.8', '3.9', '3.10']
+        os: [ubuntu-18.04, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-versions }}
 
       - name: Install Taipy without dependencies
         run: |
@@ -25,3 +30,32 @@ jobs:
           pip install pytest pytest-mock
           pytest
 
+  optionals-packages:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-versions: ['3.8', '3.9', '3.10']
+        os: [ubuntu-18.04, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - name: Add optionals dependencies
+        run: |
+          # Extract optionals packages before installing them
+          grep -n 'setup(' setup.py | cut -d ":" -f 1 | xargs -I% bash -c "expr % - 1" | xargs -I% bash -c 'head -n% setup.py' > setup_packages.py
+          echo "[print(k) for k in extras_require.keys()]" >> setup_packages.py
+          python setup_packages.py | xargs -I% bash -c "pip install .[%]"
+          rm -r taipy  # Removal of Taipy code to ensure the use of the installed package.
+          # Run test with optionals packages installed
+          pip install pytest pytest-mock
+          pytest > pytest_res
+          cat pytest_res
+          echo "Ensure that no tests are skipped"
+          tail -n1 pytest_res | grep --invert-match "skipped"
+          echo "Ensure that no warnings are issued"
+          tail -n1 pytest_res | grep --invert-match "warning"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-versions: [3.8, 3.9, 3.10]
+        python-versions: ["3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-versions: [3.8, 3.9]
+        python-versions: [3.8, 3.9, 3.10]
         os: [ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
     "python-magic-bin": ["python-magic-bin;platform_system=='Windows'"],
     "backports.zoneinfo": ["backports.zoneinfo;python_version<'3.9'"],
     "tzdata": ["tzdata;platform_system=='Windows"],
-    "rdp": ["rdp"],
+    "rdp": ["rdp>=0.8"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ test_requirements = ["pytest>=3.8"]
 
 extras_require = {
     "ngrok": ["pyngrok>=5"],
-    "python-magic": ["python-magic;platform_system!='Windows'"],
-    "python-magic-bin": ["python-magic-bin;platform_system=='Windows'"],
+    "image": ["python-magic;platform_system!='Windows'", "python-magic-bin;platform_system=='Windows'"],
     "rdp": ["rdp>=0.8"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     "simple-websocket",
     "toml",
     "tzlocal",
-    "backports.zoneinfo[tzdata];python_version<'3.9'",
+    "backports.zoneinfo;python_version<'3.9'",
 ]
 
 test_requirements = ["pytest>=3.8"]

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ requirements = [
     "simple-websocket",
     "toml",
     "tzlocal",
+    "backports.zoneinfo;python_version<'3.9'",
+    "tzdata;platform_system=='Windows;python_version<'3.9'",
 ]
 
 test_requirements = ["pytest>=3.8"]

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ requirements = [
     "pandas",
     "pyarrow",
     "python-dotenv",
-    "python-magic;platform_system!='Windows'",
-    "python-magic-bin;platform_system=='Windows'",
     "pytz",
     "simple-websocket",
     "toml",
@@ -33,6 +31,8 @@ test_requirements = ["pytest>=3.8"]
 
 extras_require = {
     "ngrok": ["pyngrok>=5"],
+    "python-magic": ["python-magic;platform_system!='Windows'"],
+    "python-magic-bin": ["python-magic-bin;platform_system=='Windows'"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ requirements = [
     "simple-websocket",
     "toml",
     "tzlocal",
-    "backports.zoneinfo;python_version<'3.9'",
-    "rdp",
 ]
 
 test_requirements = ["pytest>=3.8"]
@@ -33,6 +31,9 @@ extras_require = {
     "ngrok": ["pyngrok>=5"],
     "python-magic": ["python-magic;platform_system!='Windows'"],
     "python-magic-bin": ["python-magic-bin;platform_system=='Windows'"],
+    "backports.zoneinfo": ["backports.zoneinfo;python_version<'3.9'"],
+    "tzdata": ["tzdata;platform_system=='Windows"],
+    "rdp": ["rdp"],
 }
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     "toml",
     "tzlocal",
     "backports.zoneinfo;python_version<'3.9'",
-    "tzdata;platform_system=='Windows;python_version<'3.9'",
+    "tzdata;platform_system=='Windows;",
 ]
 
 test_requirements = ["pytest>=3.8"]

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ extras_require = {
     "ngrok": ["pyngrok>=5"],
     "python-magic": ["python-magic;platform_system!='Windows'"],
     "python-magic-bin": ["python-magic-bin;platform_system=='Windows'"],
-    "backports.zoneinfo": ["backports.zoneinfo;python_version<'3.9'"],
-    "tzdata": ["tzdata;platform_system=='Windows"],
     "rdp": ["rdp>=0.8"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ requirements = [
     "simple-websocket",
     "toml",
     "tzlocal",
-    "backports.zoneinfo;python_version<'3.9'",
-    "tzdata;platform_system=='Windows;",
+    "backports.zoneinfo[tzdata];python_version<'3.9'",
 ]
 
 test_requirements = ["pytest>=3.8"]

--- a/taipy/gui/data/content_accessor.py
+++ b/taipy/gui/data/content_accessor.py
@@ -1,13 +1,15 @@
-import typing as t
-import warnings
 import base64
 import pathlib
 import tempfile
+import typing as t
+import warnings
 from importlib import util
 from pathlib import Path
 from sys import getsizeof
 
 from ..utils import _get_non_existent_file_path
+
+_has_magic_module = False
 
 if util.find_spec("magic"):
     import magic

--- a/taipy/gui/data/utils.py
+++ b/taipy/gui/data/utils.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import typing as t
+from importlib import util
 
 import numpy as np
-from rdp import rdp
+
+_has_rdp_module = False
+
+if util.find_spec("rdp"):
+    from rdp import rdp
+
+    _has_rdp_module = True
+
 
 if t.TYPE_CHECKING:
     import pandas as pd
@@ -16,6 +24,8 @@ def df_data_filter(
     expected_row_count: t.Union[None, int],
     margin_of_error: float = 0.3,
 ) -> t.Tuple[pd.DataFrame, t.Union[None, str], str]:
+    if not _has_rdp_module:
+        return None
     if expected_row_count is not None and __df_row_count(dataframe) <= expected_row_count * (1 + margin_of_error):
         return dataframe, x_column_name, y_column_name
     df = dataframe.copy()

--- a/taipy/gui/data/utils.py
+++ b/taipy/gui/data/utils.py
@@ -24,9 +24,9 @@ def df_data_filter(
     expected_row_count: t.Union[None, int],
     margin_of_error: float = 0.3,
 ) -> t.Tuple[pd.DataFrame, t.Union[None, str], str]:
-    if not _has_rdp_module:
-        return dataframe
-    if expected_row_count is not None and __df_row_count(dataframe) <= expected_row_count * (1 + margin_of_error):
+    if not _has_rdp_module or (
+        expected_row_count is not None and __df_row_count(dataframe) <= expected_row_count * (1 + margin_of_error)
+    ):
         return dataframe, x_column_name, y_column_name
     df = dataframe.copy()
     if not x_column_name:

--- a/taipy/gui/data/utils.py
+++ b/taipy/gui/data/utils.py
@@ -25,7 +25,7 @@ def df_data_filter(
     margin_of_error: float = 0.3,
 ) -> t.Tuple[pd.DataFrame, t.Union[None, str], str]:
     if not _has_rdp_module:
-        return None
+        return dataframe
     if expected_row_count is not None and __df_row_count(dataframe) <= expected_row_count * (1 + margin_of_error):
         return dataframe, x_column_name, y_column_name
     df = dataframe.copy()

--- a/tests/taipy/gui/control/test_file_download.py
+++ b/tests/taipy/gui/control/test_file_download.py
@@ -1,6 +1,8 @@
-from taipy.gui import Gui
 import os
 import pathlib
+from importlib import util
+
+from taipy.gui import Gui
 
 
 def test_file_download_url_md(gui: Gui, helpers):
@@ -22,6 +24,8 @@ def test_file_download_file_md(gui: Gui, helpers):
             "<FileDownload",
             'defaultContent="data:image/png;base64,',
         ]
+        if not util.find_spec("magic"):
+            expected_list = ["<FileDownload", 'defaultContent="/taipy-content/taipyStatic0/TaiPyContent.', ".bin"]
         helpers.test_control_md(gui, md_string, expected_list)
 
 
@@ -42,8 +46,10 @@ def test_file_download_any_file_md(gui: Gui, helpers):
         expected_list = [
             "<FileDownload",
             'defaultContent="data:text/x',
-            'python;base64,',
+            "python;base64,",
         ]
+        if not util.find_spec("magic"):
+            expected_list = ["<FileDownload", 'defaultContent="/taipy-content/taipyStatic0/TaiPyContent.', ".bin"]
         helpers.test_control_md(gui, md_string, expected_list)
 
 

--- a/tests/taipy/gui/control/test_image.py
+++ b/tests/taipy/gui/control/test_image.py
@@ -1,6 +1,8 @@
-from taipy.gui import Gui
 import os
 import pathlib
+from importlib import util
+
+from taipy.gui import Gui
 
 
 def test_image_url_md(gui: Gui, helpers):
@@ -22,6 +24,9 @@ def test_image_file_md(gui: Gui, helpers):
             "<Image",
             'defaultContent="data:image/png;base64,',
         ]
+        if not util.find_spec("magic"):
+            expected_list = ["<Image", 'defaultContent="/taipy-content/taipyStatic0/TaiPyContent.', ".bin"]
+        print(expected_list)
         helpers.test_control_md(gui, md_string, expected_list)
 
 
@@ -43,6 +48,8 @@ def test_image_bad_file_md(gui: Gui, helpers):
             "<Image",
             'defaultContent="Invalid content: text/x',
         ]
+        if not util.find_spec("magic"):
+            expected_list = ["<Image", 'defaultContent="/taipy-content/taipyStatic0/TaiPyContent.', ".bin"]
         helpers.test_control_md(gui, md_string, expected_list)
 
 

--- a/tests/taipy/gui/control/test_image.py
+++ b/tests/taipy/gui/control/test_image.py
@@ -26,7 +26,6 @@ def test_image_file_md(gui: Gui, helpers):
         ]
         if not util.find_spec("magic"):
             expected_list = ["<Image", 'defaultContent="/taipy-content/taipyStatic0/TaiPyContent.', ".bin"]
-        print(expected_list)
         helpers.test_control_md(gui, md_string, expected_list)
 
 

--- a/tests/taipy/gui/gui_specific/test_df_filter.py
+++ b/tests/taipy/gui/gui_specific/test_df_filter.py
@@ -7,25 +7,29 @@ from taipy.gui.data.utils import df_data_filter
 
 
 def test_data_filter_1(csvdata):
-    if util.find_spec("rdp"):
-        df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 100)
+    df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 100)
+    if not util.find_spec("rdp"):
+        assert df.shape[0] == 1500
+        assert x is None
+    else:
         assert df.shape[0] == 121
         assert x == "tAiPy_index_0"
-        assert y == "Daily hospital occupancy"
+    assert y == "Daily hospital occupancy"
 
 
 def test_data_filter_2(csvdata):
-    if util.find_spec("rdp"):
-        df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 1500)
-        assert df.shape[0] == 1500
-        assert x is None
-        assert y == "Daily hospital occupancy"
+    df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 1500)
+    assert df.shape[0] == 1500
+    assert x is None
+    assert y == "Daily hospital occupancy"
 
 
 def test_data_filter_3(csvdata):
-    if util.find_spec("rdp"):
-        csvdata["DayInt"] = pd.to_datetime(csvdata["Day"]).view(np.int64)
-        df, x, y = df_data_filter(csvdata[:1500], "DayInt", "Daily hospital occupancy", 100)
+    csvdata["DayInt"] = pd.to_datetime(csvdata["Day"]).view(np.int64)
+    df, x, y = df_data_filter(csvdata[:1500], "DayInt", "Daily hospital occupancy", 100)
+    if not util.find_spec("rdp"):
+        assert df.shape[0] == 1500
+    else:
         assert df.shape[0] == 121
-        assert x == "DayInt"
-        assert y == "Daily hospital occupancy"
+    assert x == "DayInt"
+    assert y == "Daily hospital occupancy"

--- a/tests/taipy/gui/gui_specific/test_df_filter.py
+++ b/tests/taipy/gui/gui_specific/test_df_filter.py
@@ -1,3 +1,5 @@
+from importlib import util
+
 import numpy as np
 import pandas as pd
 
@@ -5,22 +7,25 @@ from taipy.gui.data.utils import df_data_filter
 
 
 def test_data_filter_1(csvdata):
-    df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 100)
-    assert df.shape[0] == 121
-    assert x == "tAiPy_index_0"
-    assert y == "Daily hospital occupancy"
+    if util.find_spec("rdp"):
+        df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 100)
+        assert df.shape[0] == 121
+        assert x == "tAiPy_index_0"
+        assert y == "Daily hospital occupancy"
 
 
 def test_data_filter_2(csvdata):
-    df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 1500)
-    assert df.shape[0] == 1500
-    assert x is None
-    assert y == "Daily hospital occupancy"
+    if util.find_spec("rdp"):
+        df, x, y = df_data_filter(csvdata[:1500], None, "Daily hospital occupancy", 1500)
+        assert df.shape[0] == 1500
+        assert x is None
+        assert y == "Daily hospital occupancy"
 
 
 def test_data_filter_3(csvdata):
-    csvdata["DayInt"] = pd.to_datetime(csvdata["Day"]).view(np.int64)
-    df, x, y = df_data_filter(csvdata[:1500], "DayInt", "Daily hospital occupancy", 100)
-    assert df.shape[0] == 121
-    assert x == "DayInt"
-    assert y == "Daily hospital occupancy"
+    if util.find_spec("rdp"):
+        csvdata["DayInt"] = pd.to_datetime(csvdata["Day"]).view(np.int64)
+        df, x, y = df_data_filter(csvdata[:1500], "DayInt", "Daily hospital occupancy", 100)
+        assert df.shape[0] == 121
+        assert x == "DayInt"
+        assert y == "Daily hospital occupancy"


### PR DESCRIPTION
Solve Bug #17
- Make libmagic and rdp optional
- use util.find_spec in tests so tests work properly
- update setup.py
- tests with optional dependencies
- all tests suites now run in both ubuntu and windows with python 3.8, 3.9, 3.10