### PR TITLE
Fix build file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     keywords="taipy-gui",
     name="taipy-gui",
-    packages=find_packages(include=["taipy", "taipy.*"]),
+    packages=find_packages(include=["taipy.gui", "taipy.gui.*"]),
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/avaiga/taipy-gui",


### PR DESCRIPTION
You can now install taipy-gui with:
```
pip install taipy-gui
```
Then run in your python interpreter:
```
import taipy.gui as gui
```

We can't have something like:
```
import taipy as gui
```
due to taipy package.

https://github.com/Avaiga/taipy/issues/8