### PR TITLE
ssl_context option

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -49,6 +49,7 @@ types-tzlocal = "*"
 types-flask = "*"
 types-Flask-Cors = "*"
 pandas-stubs = "*"
+pyopenssl = "*"
 
 [requires]
 python_version = "3"

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -16,6 +16,7 @@ import json
 import os
 import pathlib
 import re
+import ssl
 import tempfile
 import typing as t
 import warnings
@@ -988,7 +989,7 @@ class Gui:
             raise RuntimeError("frame must be a FrameType where Gui can collect the local variables.")
         self.__frame = frame
 
-    def run(self, run_server: bool = True, run_in_thread: bool = False, **kwargs) -> t.Optional[Flask]:
+    def run(self, run_server: bool = True, run_in_thread: bool = False, ssl_context: t.Optional[t.Union[ssl.SSLContext, t.Tuple[str, t.Optional[str]], t.Literal['adhoc']]] = None, **kwargs) -> t.Optional[Flask]:
         """
         Starts the server that delivers pages to Web clients.
 
@@ -1006,6 +1007,9 @@ class Gui:
                 If set to _True_, the Web server is run is a separated thread.
                 Note that if you are running in an IPython notebook context, the Web
                 server is always run in a separate thread.
+            ssl_context (Optional[Union[ssl.SSLContext, Tuple[str, Optional[str]], te.Literal['adhoc']]]):
+                Configure TLS to serve over HTTPS. Can be an ssl.SSLContext object, a (cert_file, key_file) tuple to
+                create a typical context, or the string 'adhoc' to generate a temporary self-signed certificate.
             kwargs: Additional keywords that configure how this `Gui` is run.
                 Please refer to the
                 [Configuration](../gui/configuration.md#configuring-the-gui-instance)
@@ -1150,6 +1154,7 @@ class Gui:
             use_reloader=app_config["use_reloader"],
             flask_log=app_config["flask_log"],
             run_in_thread=run_in_thread,
+            ssl_context=ssl_context
         )
 
     def stop(self):

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -1027,7 +1027,8 @@ class Gui:
                 server is always run in a separate thread.
             ssl_context (Optional[Union[ssl.SSLContext, Tuple[str, Optional[str]], te.Literal['adhoc']]]):
                 Configure TLS to serve over HTTPS. Can be an ssl.SSLContext object, a (cert_file, key_file) tuple to
-                create a typical context, or the string 'adhoc' to generate a temporary self-signed certificate.
+                create a typical context, or the string 'adhoc' to generate a temporary self-signed certificate.</br>
+                The default value is None.
             kwargs: Additional keywords that configure how this `Gui` is run.
                 Please refer to the
                 [Configuration](../gui/configuration.md#configuring-the-gui-instance)

--- a/taipy/gui/server.py
+++ b/taipy/gui/server.py
@@ -65,7 +65,7 @@ class _Server:
             ping_interval=5,
             json=json,
         )
-        # this is necessary since CORS resources can't been None eventhough python stub allows for None
+
         CORS(self._flask)
 
         if force_https or content_security_policy:
@@ -220,7 +220,7 @@ class _Server:
     def _run_notebook(self):
         self._ws.run(self._flask, host=self._host, port=self._port, debug=False, use_reloader=False)
 
-    def runWithWS(self, host, port, debug, use_reloader, flask_log, run_in_thread):
+    def runWithWS(self, host, port, debug, use_reloader, flask_log, run_in_thread, ssl_context):
         host_value = host if host != "0.0.0.0" else "localhost"
         if not flask_log:
             log = logging.getLogger("werkzeug")
@@ -239,4 +239,4 @@ class _Server:
             self._thread = _KillableThread(target=self._run_notebook)
             self._thread.start()
             return
-        self._ws.run(self._flask, host=host, port=port, debug=debug, use_reloader=use_reloader)
+        self._ws.run(self._flask, host=host, port=port, debug=debug, use_reloader=use_reloader, ssl_context=ssl_context)


### PR DESCRIPTION
Solve issue #221 

You can test adhoc ssl certificate locally by:
1. `pipenv install --dev` to install pyopenssl
2. gui.run(ssl_context='adhoc') 