### PR TITLE
Prevent the same variable to be evaluated multiple times in on_change function (#257)

### DIFF
--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -190,7 +190,7 @@ class Gui:
         self.on_change: t.Optional[t.Callable] = None
         self.on_init: t.Optional[t.Callable] = None
 
-        # gui syncrhonous state variable
+        # gui synchronous state variable
         self.__modified_vars_update_var: t.Optional[t.Set] = None
 
         # Load default config

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -315,6 +315,7 @@ class Gui:
             var_name = holder.get_name()
         hash_expr = self.__evaluator.get_hash_from_expr(var_name)
         if self.__modified_vars_update_var is not None and hash_expr in self.__modified_vars_update_var:
+            warnings.warn("Failed to update {var_name} as it has been updated previously. Review `on_change` function to fix this issue.")
             return
         modified_vars = {hash_expr}
         # Use custom attrsetter function to allow value binding for _MapDict

--- a/taipy/gui/gui.py
+++ b/taipy/gui/gui.py
@@ -314,8 +314,8 @@ class Gui:
         if holder:
             var_name = holder.get_name()
         hash_expr = self.__evaluator.get_hash_from_expr(var_name)
+        # if the variable has been evaluated then skip updating to prevent infinite loop
         if self.__modified_vars_update_var is not None and hash_expr in self.__modified_vars_update_var:
-            warnings.warn("Failed to update {var_name} as it has been updated previously. Review `on_change` function to fix this issue.")
             return
         modified_vars = {hash_expr}
         # Use custom attrsetter function to allow value binding for _MapDict

--- a/tests/taipy/gui/e2e/with_action/test_slider_action.py
+++ b/tests/taipy/gui/e2e/with_action/test_slider_action.py
@@ -56,7 +56,7 @@ def test_slider_action_on_change(page: "Page", gui: Gui, helpers):
 
     def on_change(state, var, val):
         if var == "d.v2":
-            d = {"v1": 2 * val, "v2": val}
+            d = {"v1": 2 * val}
             state.d.update(d)
 
     page_md = """


### PR DESCRIPTION
Solve Issue #257 

With this udpate, variable x in the on_change function wont be updated in this case since x has been updated before --> No inifinite loop.

```
from taipy.gui import Gui

x = 10

def on_change(state, var, val):
    if var == "x":
        state.x = val * 2

gui = Gui(page="""

x = <|{x}|>

x * 10 = <|{x*10}|>

Slider for x: <|{x}|slider|>

""")

gui.run()
```