### PR TITLE
access module context from state class (#315)

### DIFF
--- a/taipy/gui/__init__.py
+++ b/taipy/gui/__init__.py
@@ -67,7 +67,7 @@ from .gui import Gui
 from .gui_actions import (
     download,
     get_context_id,
-    get_page_scope,
+    get_module_name_from_state,
     hold_control,
     invoke_state_callback,
     navigate,

--- a/taipy/gui/__init__.py
+++ b/taipy/gui/__init__.py
@@ -64,7 +64,16 @@ application.
 """
 
 from .gui import Gui
-from .gui_actions import download, hold_control, navigate, notify, resume_control, get_context_id, invoke_state_callback
+from .gui_actions import (
+    download,
+    get_context_id,
+    get_page_scope,
+    hold_control,
+    invoke_state_callback,
+    navigate,
+    notify,
+    resume_control,
+)
 from .icon import Icon
 from .renderers import Html, Markdown
 from .state import State

--- a/taipy/gui/gui_actions.py
+++ b/taipy/gui/gui_actions.py
@@ -136,6 +136,26 @@ def get_context_id(state: State) -> t.Optional[str]:
 
 
 def get_module_name_from_state(state: State) -> t.Optional[str]:
+    """Get the module name that triggered a callback.
+
+    Pages can be defined in different modules yet share callbacks declared elsewhere (typically, the
+    application's main module).
+
+    This function returns the name of the module where the page (that holds the control that triggered the
+    callback) was declared.  This lets applications implement different behaviors depending on what page
+    is involved.
+
+    This function must be called only in the body of a callback function.
+
+    Arguments:
+
+        state: (State^): The `State` instance, which is an argument of the callback function.
+
+    Returns:
+
+        str: The name of the module that holds the definition of the page containing the control that
+            triggered this callback.
+    """
     if state and isinstance(state._gui, Gui):
         return state._gui._get_locals_context()
     return None

--- a/taipy/gui/gui_actions.py
+++ b/taipy/gui/gui_actions.py
@@ -135,7 +135,7 @@ def get_context_id(state: State) -> t.Optional[str]:
     return None
 
 
-def get_page_scope(state: State) -> t.Optional[str]:
+def get_module_name_from_state(state: State) -> t.Optional[str]:
     if state and isinstance(state._gui, Gui):
         return state._gui._get_locals_context()
     return None

--- a/taipy/gui/gui_actions.py
+++ b/taipy/gui/gui_actions.py
@@ -134,7 +134,16 @@ def get_context_id(state: State) -> t.Optional[str]:
         return state._gui._get_client_id()
     return None
 
-def invoke_state_callback(gui: Gui, context_id: str, user_callback: t.Callable, args: t.Union[t.Tuple, t.List]) -> t.Any:
+
+def get_page_scope(state: State) -> t.Optional[str]:
+    if state and isinstance(state._gui, Gui):
+        return state._gui._get_locals_context()
+    return None
+
+
+def invoke_state_callback(
+    gui: Gui, context_id: str, user_callback: t.Callable, args: t.Union[t.Tuple, t.List]
+) -> t.Any:
     """Invoke a user callback with context.
 
     Arguments:

--- a/taipy/gui/state.py
+++ b/taipy/gui/state.py
@@ -67,7 +67,6 @@ class State:
     """
 
     __gui_attr = "_gui"
-    __module_attr = "_module"
     __attrs = (__gui_attr, "_user_var_list")
     __methods = ("assign", "_get_placeholder", "_set_placeholder", "_get_gui_attr", "_get_placeholder_attrs")
     __placeholder_attrs = ("_taipy_p1",)
@@ -84,11 +83,9 @@ class State:
     def __getattribute__(self, name: str) -> t.Any:
         if name in State.__methods:
             return super().__getattribute__(name)
-        gui: Gui = super().__getattribute__(State.__gui_attr)
+        gui = super().__getattribute__(State.__gui_attr)
         if name == State.__gui_attr:
             return gui
-        if name == State.__module_attr:
-            return gui._get_locals_context()
         if name in State.__excluded_attrs:
             raise AttributeError(f"Variable '{name}' is protected and is not accessible.")
         if name not in super().__getattribute__(State.__attrs[1]):

--- a/taipy/gui/state.py
+++ b/taipy/gui/state.py
@@ -67,7 +67,8 @@ class State:
     """
 
     __gui_attr = "_gui"
-    __attrs = (__gui_attr, "_user_var_list")
+    __module_attr = "_module"
+    __attrs = (__gui_attr, "_user_var_list", __module_attr)
     __methods = ("assign", "_get_placeholder", "_set_placeholder", "_get_gui_attr", "_get_placeholder_attrs")
     __placeholder_attrs = ("_taipy_p1",)
     __excluded_attrs = __attrs + __methods + __placeholder_attrs
@@ -83,9 +84,11 @@ class State:
     def __getattribute__(self, name: str) -> t.Any:
         if name in State.__methods:
             return super().__getattribute__(name)
-        gui = super().__getattribute__(State.__gui_attr)
+        gui: Gui = super().__getattribute__(State.__gui_attr)
         if name == State.__gui_attr:
             return gui
+        if name == State.__module_attr:
+            return gui._get_locals_context()
         if name in State.__excluded_attrs:
             raise AttributeError(f"Variable '{name}' is protected and is not accessible.")
         if name not in super().__getattribute__(State.__attrs[1]):

--- a/taipy/gui/state.py
+++ b/taipy/gui/state.py
@@ -68,7 +68,7 @@ class State:
 
     __gui_attr = "_gui"
     __module_attr = "_module"
-    __attrs = (__gui_attr, "_user_var_list", __module_attr)
+    __attrs = (__gui_attr, "_user_var_list")
     __methods = ("assign", "_get_placeholder", "_set_placeholder", "_get_gui_attr", "_get_placeholder_attrs")
     __placeholder_attrs = ("_taipy_p1",)
     __excluded_attrs = __attrs + __methods + __placeholder_attrs


### PR DESCRIPTION
Solve Issue #315 

This would allow a function to be declared on the main module and that function can be used accross multiple modules
```
def reset_data(state):
    if "page1" in state._module:
        state.df = df
        state.filter_value = 0
        notify(state, message="Table data is reset")
    if "page2" in state._module:
        state.chart_data = df
        state.fv = 0
        notify(state, message="Chart data is reset")
```