### PR TITLE
#323 add a version parameter to the request

### DIFF
--- a/gui/src/components/pages/TaipyRendered.tsx
+++ b/gui/src/components/pages/TaipyRendered.tsx
@@ -61,7 +61,7 @@ const TaipyRendered = (props: TaipyRenderedProps) => {
             dispatch(createPartialAction(path.slice(1), false));
         } else {
             axios
-            .get<AxiosRenderer>(`/taipy-jsx${path}`, {params: {client_id: state.id || ""}})
+            .get<AxiosRenderer>(`/taipy-jsx${path}`, {params: {client_id: state.id || "", v: "1.1"}})
             .then((result) => {
                 // set rendered JSX and CSS style from fetch result
                 typeof result.data.jsx === "string" && setJSX(result.data.jsx);


### PR DESCRIPTION
so that we won't get permanent redirect kicking in from 1.0
This should hold the real (read from back-end) value in sunbsequent versions