### PR TITLE
#461 support absolute URLS in library.get_scripts and get_styles

### DIFF
--- a/src/taipy/gui/extension/library.py
+++ b/src/taipy/gui/extension/library.py
@@ -225,6 +225,8 @@ class ElementLibrary(ABC):
     def get_scripts(self) -> t.List[str]:
         """
         Returns the list of resources names for the scripts.
+        If a resource name is an absolute URL it will be used as is, if it's not it will be
+        passed to get_resource to retrieve a local Path to the resource.
 
         The default implementation returns an empty list, indicating that this library contains
         no custom visual elements.

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -23,6 +23,7 @@ import typing as t
 import warnings
 from importlib import util
 from types import FrameType
+from urllib.parse import urlparse
 
 import __main__
 import markdown as md_lib
@@ -1641,13 +1642,13 @@ class Gui:
         extension_bp = Blueprint("taipy_extensions", __name__)
         extension_bp.add_url_rule(f"{Gui._EXTENSION_ROOT}<path:path>", view_func=self.__serve_extension)
         scripts = [
-            f"{Gui._EXTENSION_ROOT}{name}/{s}"
+            s if bool(urlparse(s).netloc) else f"{Gui._EXTENSION_ROOT}{name}/{s}"
             for name, libs in Gui.__extensions.items()
             for lib in libs
             for s in (lib.get_scripts() or [])
         ]
         styles = [
-            f"{Gui._EXTENSION_ROOT}{name}/{s}"
+            s if bool(urlparse(s).netloc) else f"{Gui._EXTENSION_ROOT}{name}/{s}"
             for name, libs in Gui.__extensions.items()
             for lib in libs
             for s in (lib.get_styles() or [])


### PR DESCRIPTION
Will need a bit of doc I guess :
get_scripts
"""
Returns the list of resources names for the scripts.
if a resource name is an absolute URL it will be used as is, if it's not it will be passed to get_resource to retrieve a local Path to the resource
...