### PR TITLE
#386 edit boolean in tables

### DIFF
--- a/gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -298,7 +298,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
                           return pv;
                       }, "-agg")
                     : "";
-                const cols = colsOrder.map((col) => columns[col].dfid);
+                const cols = colsOrder.map((col) => columns[col].dfid).filter(c => c != EDIT_COL);
                 const key = `Infinite-${cols.join()}-${orderBy}-${order}${agg}`;
                 page.current = {
                     key: key,

--- a/gui/src/components/Taipy/PaginatedTable.spec.tsx
+++ b/gui/src/components/Taipy/PaginatedTable.spec.tsx
@@ -113,7 +113,7 @@ const editableValue = {
         ],
         rowcount: 2,
         start: 0,
-    }
+    },
 };
 const editableColumns = JSON.stringify({
     bool: { dfid: "bool", type: "bool", index: 0 },
@@ -121,7 +121,6 @@ const editableColumns = JSON.stringify({
     float: { dfid: "float", type: "float", index: 2 },
     Code: { dfid: "Code", type: "str", index: 3 },
 });
-
 
 describe("PaginatedTable Component", () => {
     it("renders", async () => {
@@ -365,6 +364,21 @@ describe("PaginatedTable Component", () => {
             await userEvent.click(clearButton);
             expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
             expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+
+            await userEvent.click(edits[2]);
+            await userEvent.click(getByTestId("CheckIcon"));
+            expect(dispatch).toHaveBeenCalledWith({
+                name: "",
+                payload: {
+                    action: "onEdit",
+                    args: [],
+                    col: "float",
+                    index: 0,
+                    user_value: 1.5,
+                    value: 1.5,
+                },
+                type: "SEND_ACTION_ACTION",
+            });
         });
     });
     it("can add", async () => {
@@ -378,11 +392,20 @@ describe("PaginatedTable Component", () => {
 
         const addButton = getByTestId("AddIcon");
         await userEvent.click(addButton);
+        expect(dispatch).toHaveBeenCalledWith({
+            name: "",
+            payload: {
+                action: "onAdd",
+                args: [],
+                index: 0,
+            },
+            type: "SEND_ACTION_ACTION",
+        });
     });
     it("can delete", async () => {
         const dispatch = jest.fn();
         const state: TaipyState = INITIAL_STATE;
-        const { getAllByTestId, rerender } = render(
+        const { getAllByTestId, getByTestId, queryAllByTestId, rerender } = render(
             <TaipyContext.Provider value={{ state, dispatch }}>
                 <PaginatedTable data={undefined} columns={editableColumns} showAll={true} onDelete="onDelete" />
             </TaipyContext.Provider>
@@ -402,5 +425,33 @@ describe("PaginatedTable Component", () => {
         const deleteButtons = getAllByTestId("DeleteIcon");
         expect(deleteButtons).not.toHaveLength(0);
         await userEvent.click(deleteButtons[0]);
+        const checkButton = getByTestId("CheckIcon");
+        getByTestId("ClearIcon");
+        await userEvent.click(checkButton);
+        expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
+        expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+
+        await userEvent.click(deleteButtons[1]);
+        const clearButton = getByTestId("ClearIcon");
+        const input = document.querySelector("input");
+        expect(input).not.toBeNull();
+        input && (await userEvent.type(input, "1"));
+        await userEvent.click(clearButton);
+        expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
+        expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+
+        await userEvent.click(deleteButtons[2]);
+        const input2 = document.querySelector("input");
+        expect(input2).not.toBeNull();
+        input2 && (await userEvent.type(input2, "{enter}"));
+        expect(dispatch).toHaveBeenCalledWith({
+            name: "",
+            payload: {
+                action: "onDelete",
+                args: [],
+                index: 0,
+            },
+            type: "SEND_ACTION_ACTION",
+        });
     });
 });

--- a/gui/src/components/Taipy/PaginatedTable.spec.tsx
+++ b/gui/src/components/Taipy/PaginatedTable.spec.tsx
@@ -365,6 +365,7 @@ describe("PaginatedTable Component", () => {
             expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
             expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
 
+            dispatch.mockClear();
             await userEvent.click(edits[2]);
             await userEvent.click(getByTestId("CheckIcon"));
             expect(dispatch).toHaveBeenCalledWith({
@@ -379,6 +380,43 @@ describe("PaginatedTable Component", () => {
                 },
                 type: "SEND_ACTION_ACTION",
             });
+
+            await userEvent.click(edits[3]);
+            const input2 = document.querySelector("input");
+            expect(input2).not.toBeNull();
+            if (input2) {
+                if (input2.type == "checkbox") {
+                    await userEvent.click(input2);
+                    await userEvent.click(getByTestId("ClearIcon"));
+                } else {
+                    await userEvent.type(input2, "{Esc}");
+                }
+            }
+
+            dispatch.mockClear();
+            await userEvent.click(edits[5]);
+            const input3 = document.querySelector("input");
+            expect(input3).not.toBeNull();
+            if (input3) {
+                if (input3.type == "checkbox") {
+                    await userEvent.click(input3);
+                    await userEvent.click(getByTestId("CheckIcon"));
+                } else {
+                    await userEvent.type(input3, "{Enter}");
+                }
+            }
+            expect(dispatch).toHaveBeenCalledWith({
+                name: "",
+                payload: {
+                    action: "onEdit",
+                    args: [],
+                    col: "int",
+                    index: 1,
+                    user_value: 823,
+                    value: 823,
+                },
+                type: "SEND_ACTION_ACTION",
+            });
         });
     });
     it("can add", async () => {
@@ -390,6 +428,7 @@ describe("PaginatedTable Component", () => {
             </TaipyContext.Provider>
         );
 
+        dispatch.mockClear();
         const addButton = getByTestId("AddIcon");
         await userEvent.click(addButton);
         expect(dispatch).toHaveBeenCalledWith({
@@ -422,7 +461,7 @@ describe("PaginatedTable Component", () => {
             </TaipyContext.Provider>
         );
 
-        const deleteButtons = getAllByTestId("DeleteIcon");
+        let deleteButtons = getAllByTestId("DeleteIcon");
         expect(deleteButtons).not.toHaveLength(0);
         await userEvent.click(deleteButtons[0]);
         const checkButton = getByTestId("CheckIcon");
@@ -441,6 +480,14 @@ describe("PaginatedTable Component", () => {
         expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
 
         await userEvent.click(deleteButtons[2]);
+        const input3 = document.querySelector("input");
+        expect(input3).not.toBeNull();
+        input3 && (await userEvent.type(input3, "{esc}"));
+
+        deleteButtons = getAllByTestId("DeleteIcon");
+
+        dispatch.mockClear();
+        await userEvent.click(deleteButtons[0]);
         const input2 = document.querySelector("input");
         expect(input2).not.toBeNull();
         input2 && (await userEvent.type(input2, "{enter}"));

--- a/gui/src/components/Taipy/PaginatedTable.spec.tsx
+++ b/gui/src/components/Taipy/PaginatedTable.spec.tsx
@@ -95,6 +95,34 @@ const tableColumns = JSON.stringify({
     "Daily hospital occupancy": { dfid: "Daily hospital occupancy", type: "int64" },
 });
 
+const editableValue = {
+    "0--1-bool,int,float,Code--asc": {
+        data: [
+            {
+                bool: true,
+                int: 856,
+                float: 1.5,
+                Code: "AUT",
+            },
+            {
+                bool: false,
+                int: 823,
+                float: 2.5,
+                Code: "ZZZ",
+            },
+        ],
+        rowcount: 2,
+        start: 0,
+    }
+};
+const editableColumns = JSON.stringify({
+    bool: { dfid: "bool", type: "bool", index: 0 },
+    int: { dfid: "int", type: "int", index: 1 },
+    float: { dfid: "float", type: "float", index: 2 },
+    Code: { dfid: "Code", type: "str", index: 3 },
+});
+
+
 describe("PaginatedTable Component", () => {
     it("renders", async () => {
         const { getByText } = render(<PaginatedTable data={undefined} columns={tableColumns} />);
@@ -150,7 +178,7 @@ describe("PaginatedTable Component", () => {
                 aggregates: [],
                 applies: undefined,
                 styles: {},
-                filters: []
+                filters: [],
             },
             type: "REQUEST_DATA_UPDATE",
         });
@@ -179,7 +207,7 @@ describe("PaginatedTable Component", () => {
                 aggregates: [],
                 applies: undefined,
                 styles: {},
-                filters: []
+                filters: [],
             },
             type: "REQUEST_DATA_UPDATE",
         });
@@ -224,7 +252,7 @@ describe("PaginatedTable Component", () => {
                 aggregates: [],
                 applies: undefined,
                 styles: {},
-                filters: []
+                filters: [],
             },
             type: "REQUEST_DATA_UPDATE",
         });
@@ -257,7 +285,7 @@ describe("PaginatedTable Component", () => {
             </TaipyContext.Provider>
         );
         rerender(
-            <TaipyContext.Provider value={{ state: {...state}, dispatch }}>
+            <TaipyContext.Provider value={{ state: { ...state }, dispatch }}>
                 <PaginatedTable selected={selected} data={tableValue as TableValueType} columns={tableColumns} />
             </TaipyContext.Provider>
         );
@@ -268,5 +296,111 @@ describe("PaginatedTable Component", () => {
                 : expect(elt.parentElement?.parentElement).toHaveClass("Mui-selected")
         );
         expect(document.querySelectorAll(".Mui-selected")).toHaveLength(selected.length);
+    });
+    describe("Edit Mode", () => {
+        it("displays the data with edit buttons", async () => {
+            const dispatch = jest.fn();
+            const state: TaipyState = INITIAL_STATE;
+            const { getAllByTestId, queryAllByTestId, rerender } = render(
+                <TaipyContext.Provider value={{ state, dispatch }}>
+                    <PaginatedTable data={undefined} columns={editableColumns} onEdit="onEdit" showAll={true} />
+                </TaipyContext.Provider>
+            );
+
+            rerender(
+                <TaipyContext.Provider value={{ state: { ...state }, dispatch }}>
+                    <PaginatedTable
+                        data={editableValue as TableValueType}
+                        columns={editableColumns}
+                        onEdit="onEdit"
+                        showAll={true}
+                    />
+                </TaipyContext.Provider>
+            );
+
+            expect(document.querySelectorAll(".MuiSwitch-root")).not.toHaveLength(0);
+            expect(getAllByTestId("EditIcon")).not.toHaveLength(0);
+            expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
+            expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+        });
+        it("can edit", async () => {
+            const dispatch = jest.fn();
+            const state: TaipyState = INITIAL_STATE;
+            const { getByTestId, queryAllByTestId, getAllByTestId, rerender } = render(
+                <TaipyContext.Provider value={{ state, dispatch }}>
+                    <PaginatedTable data={undefined} columns={editableColumns} onEdit="onEdit" showAll={true} />
+                </TaipyContext.Provider>
+            );
+
+            rerender(
+                <TaipyContext.Provider value={{ state: { ...state }, dispatch }}>
+                    <PaginatedTable
+                        data={editableValue as TableValueType}
+                        columns={editableColumns}
+                        onEdit="onEdit"
+                        showAll={true}
+                    />
+                </TaipyContext.Provider>
+            );
+
+            const edits = getAllByTestId("EditIcon");
+            await userEvent.click(edits[0]);
+            const checkButton = getByTestId("CheckIcon");
+            getByTestId("ClearIcon");
+            await userEvent.click(checkButton);
+            expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
+            expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+
+            await userEvent.click(edits[1]);
+            const clearButton = getByTestId("ClearIcon");
+            const input = document.querySelector("input");
+            expect(input).not.toBeNull();
+            if (input) {
+                if (input.type == "checkbox") {
+                    await userEvent.click(input);
+                } else {
+                    await userEvent.type(input, "1");
+                }
+            }
+            await userEvent.click(clearButton);
+            expect(queryAllByTestId("CheckIcon")).toHaveLength(0);
+            expect(queryAllByTestId("ClearIcon")).toHaveLength(0);
+        });
+    });
+    it("can add", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getByTestId } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <PaginatedTable data={undefined} columns={editableColumns} showAll={true} onAdd="onAdd" />
+            </TaipyContext.Provider>
+        );
+
+        const addButton = getByTestId("AddIcon");
+        await userEvent.click(addButton);
+    });
+    it("can delete", async () => {
+        const dispatch = jest.fn();
+        const state: TaipyState = INITIAL_STATE;
+        const { getAllByTestId, rerender } = render(
+            <TaipyContext.Provider value={{ state, dispatch }}>
+                <PaginatedTable data={undefined} columns={editableColumns} showAll={true} onDelete="onDelete" />
+            </TaipyContext.Provider>
+        );
+
+        rerender(
+            <TaipyContext.Provider value={{ state: { ...state }, dispatch }}>
+                <PaginatedTable
+                    data={editableValue as TableValueType}
+                    columns={editableColumns}
+                    showAll={true}
+                    onDelete="onDelete"
+                />
+            </TaipyContext.Provider>
+        );
+
+        const deleteButtons = getAllByTestId("DeleteIcon");
+        expect(deleteButtons).not.toHaveLength(0);
+        await userEvent.click(deleteButtons[0]);
     });
 });

--- a/gui/src/components/Taipy/PaginatedTable.tsx
+++ b/gui/src/components/Taipy/PaginatedTable.tsx
@@ -177,7 +177,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                   return pv;
               }, "-agg")
             : "";
-        const cols = colsOrder.map((col) => columns[col].dfid);
+        const cols = colsOrder.map((col) => columns[col].dfid).filter(c => c != EDIT_COL);
         pageKey.current = `${startIndex}-${endIndex}-${cols.join()}-${orderBy}-${order}${agg}${appliedFilters.map(
             (af) => `${af.col}${af.action}${af.value}`
         )}`;

--- a/gui/src/components/Taipy/tableUtils.tsx
+++ b/gui/src/components/Taipy/tableUtils.tsx
@@ -80,62 +80,7 @@ export const EDIT_COL = "taipy_edit";
 
 export const LINE_STYLE = "__taipy_line_style__";
 
-export const getsortByIndex = (cols: Record<string, ColumnDesc>) => (key1: string, key2: string) => {
-    if (cols[key1].index < cols[key2].index) {
-        return -1;
-    }
-    if (cols[key1].index > cols[key2].index) {
-        return 1;
-    }
-    return 0;
-};
-
 export const defaultDateFormat = "yyyy/MM/dd";
-
-const formatValue = (val: RowValue, col: ColumnDesc, formatConf: FormatConfig, nanValue?: string): string => {
-    if (val === null || val === undefined) {
-        return "";
-    }
-    switch (col.type) {
-        case "datetime":
-            return getDateTimeString(val as string, col.format || defaultDateFormat, formatConf, col.tz);
-        case "int":
-        case "float":
-            if (val === "NaN") {
-                return nanValue || "";
-            }
-            return getNumberString(val as number, col.format, formatConf);
-        default:
-            return val as string;
-    }
-};
-const VALID_BOOLEAN_STRINGS = ["true", "1", "t", "y", "yes", "yeah", "sure"];
-
-const isBooleanTrue = (val: RowValue) =>
-    typeof val == "string" ? VALID_BOOLEAN_STRINGS.some((s) => s == val.trim().toLowerCase()) : !!val;
-
-const renderCellValue = (val: RowValue | boolean, col: ColumnDesc, formatConf: FormatConfig, nanValue?: string) => {
-    if (val !== null && val !== undefined && col.type && col.type.startsWith("bool")) {
-        return <Switch checked={val as boolean} size="small" title={val ? "True" : "False"} sx={iconInRowSx} />;
-    }
-    return <>{formatValue(val as RowValue, col, formatConf, nanValue)}</>;
-};
-
-const getCellProps = (col: ColumnDesc, base: Partial<TableCellProps> = {}): Partial<TableCellProps> => {
-    switch (col.type) {
-        case "int":
-        case "float":
-            base.align = "right";
-            break;
-        case "bool":
-            base.align = "center";
-            break;
-    }
-    if (col.width) {
-        base.width = col.width;
-    }
-    return base;
-};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TableValueType = Record<string, Record<string, any>>;
@@ -176,6 +121,9 @@ export const baseBoxSx = { width: "100%" };
 export const paperSx = { width: "100%", mb: 2 };
 export const tableSx = { minWidth: 250 };
 export const headBoxSx = { display: "flex", alignItems: "flex-start" };
+export const iconInRowSx = { fontSize: "body2.fontSize" };
+const cellBoxSx = { display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center" } as CSSProperties;
+const tableFontSx = { fontSize: "body2.fontSize" };
 
 export interface OnCellValidation {
     (value: RowValue, rowIndex: number, colName: string, userValue: string): void;
@@ -197,8 +145,57 @@ interface EditableCellProps {
     tableCellProps?: Partial<TableCellProps>;
 }
 
-export const addDeleteColumn = (render: number, columns: Record<string, ColumnDesc>) => {
-    if (render) {
+export const getsortByIndex = (cols: Record<string, ColumnDesc>) => (key1: string, key2: string) =>
+    cols[key1].index < cols[key2].index ? -1 : cols[key1].index > cols[key2].index ? 1 : 0;
+
+const formatValue = (val: RowValue, col: ColumnDesc, formatConf: FormatConfig, nanValue?: string): string => {
+    if (val === null || val === undefined) {
+        return "";
+    }
+    switch (col.type) {
+        case "datetime":
+            return getDateTimeString(val as string, col.format || defaultDateFormat, formatConf, col.tz);
+        case "int":
+        case "float":
+            if (val === "NaN") {
+                return nanValue || "";
+            }
+            return getNumberString(val as number, col.format, formatConf);
+        default:
+            return val as string;
+    }
+};
+
+const VALID_BOOLEAN_STRINGS = ["true", "1", "t", "y", "yes", "yeah", "sure"];
+
+const isBooleanTrue = (val: RowValue) =>
+    typeof val == "string" ? VALID_BOOLEAN_STRINGS.some((s) => s == val.trim().toLowerCase()) : !!val;
+
+const renderCellValue = (val: RowValue | boolean, col: ColumnDesc, formatConf: FormatConfig, nanValue?: string) => {
+    if (val !== null && val !== undefined && col.type && col.type.startsWith("bool")) {
+        return <Switch checked={val as boolean} size="small" title={val ? "True" : "False"} sx={iconInRowSx} />;
+    }
+    return <>{formatValue(val as RowValue, col, formatConf, nanValue)}</>;
+};
+
+const getCellProps = (col: ColumnDesc, base: Partial<TableCellProps> = {}): Partial<TableCellProps> => {
+    switch (col.type) {
+        case "int":
+        case "float":
+            base.align = "right";
+            break;
+        case "bool":
+            base.align = "center";
+            break;
+    }
+    if (col.width) {
+        base.width = col.width;
+    }
+    return base;
+};
+
+export const addDeleteColumn = (nbToRender: number, columns: Record<string, ColumnDesc>) => {
+    if (nbToRender) {
         Object.keys(columns).forEach((key) => columns[key].index++);
         columns[EDIT_COL] = {
             dfid: EDIT_COL,
@@ -206,7 +203,7 @@ export const addDeleteColumn = (render: number, columns: Record<string, ColumnDe
             format: "",
             title: "",
             index: 0,
-            width: render * 4 + "em",
+            width: nbToRender * 4 + "em",
             filter: false,
         };
     }
@@ -217,10 +214,6 @@ export const getClassName = (row: Record<string, unknown>, style?: string) =>
     style ? (row[style] as string) : undefined;
 
 const setInputFocus = (input: HTMLInputElement) => input && input.focus();
-
-const cellBoxSx = { display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center" } as CSSProperties;
-export const iconInRowSx = { fontSize: "body2.fontSize" };
-const tableFontSx = { fontSize: "body2.fontSize" };
 
 export const EditableCell = (props: EditableCellProps) => {
     const {

--- a/gui/src/components/Taipy/tableUtils.tsx
+++ b/gui/src/components/Taipy/tableUtils.tsx
@@ -111,7 +111,8 @@ const formatValue = (val: RowValue, col: ColumnDesc, formatConf: FormatConfig, n
 };
 const VALID_BOOLEAN_STRINGS = ["true", "1", "t", "y", "yes", "yeah", "sure"];
 
-const isBooleanTrue = (val: RowValue) => typeof val == "string" ? VALID_BOOLEAN_STRINGS.some(s => s == val.trim().toLowerCase()) : !!val;
+const isBooleanTrue = (val: RowValue) =>
+    typeof val == "string" ? VALID_BOOLEAN_STRINGS.some((s) => s == val.trim().toLowerCase()) : !!val;
 
 const renderCellValue = (val: RowValue | boolean, col: ColumnDesc, formatConf: FormatConfig, nanValue?: string) => {
     if (val !== null && val !== undefined && col.type && col.type.startsWith("bool")) {
@@ -238,6 +239,7 @@ export const EditableCell = (props: EditableCellProps) => {
     const [deletion, setDeletion] = useState(false);
 
     const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setVal(e.target.value), []);
+    const onBoolChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setVal(e.target.checked), []);
 
     const onCheckClick = useCallback(() => {
         let castedVal = val;
@@ -259,7 +261,7 @@ export const EditableCell = (props: EditableCellProps) => {
                     // ignore
                 }
                 break;
-            }
+        }
         onValidation && onValidation(castedVal, rowIndex, colDesc.dfid, val as string);
         setEdit((e) => !e);
     }, [onValidation, val, rowIndex, colDesc.dfid, colDesc.type]);
@@ -306,24 +308,45 @@ export const EditableCell = (props: EditableCellProps) => {
     return (
         <TableCell {...getCellProps(colDesc, tableCellProps)} className={className}>
             {edit ? (
-                <Input
-                    value={val}
-                    onChange={onChange}
-                    onKeyDown={onKeyDown}
-                    inputRef={setInputFocus}
-                    margin="dense"
-                    sx={tableFontSx}
-                    endAdornment={
-                        <>
+                colDesc.type?.startsWith("bool") ? (
+                    <Box sx={cellBoxSx}>
+                        <Switch
+                            checked={val as boolean}
+                            size="small"
+                            title={val ? "True" : "False"}
+                            sx={iconInRowSx}
+                            onChange={onBoolChange}
+                            inputRef={setInputFocus}
+                        />
+                        <div>
                             <IconButton onClick={onCheckClick} size="small" sx={iconInRowSx}>
                                 <CheckIcon fontSize="inherit" />
                             </IconButton>
                             <IconButton onClick={onEditClick} size="small" sx={iconInRowSx}>
                                 <ClearIcon fontSize="inherit" />
                             </IconButton>
-                        </>
-                    }
-                />
+                        </div>
+                    </Box>
+                ) : (
+                    <Input
+                        value={val}
+                        onChange={onChange}
+                        onKeyDown={onKeyDown}
+                        inputRef={setInputFocus}
+                        margin="dense"
+                        sx={tableFontSx}
+                        endAdornment={
+                            <>
+                                <IconButton onClick={onCheckClick} size="small" sx={iconInRowSx}>
+                                    <CheckIcon fontSize="inherit" />
+                                </IconButton>
+                                <IconButton onClick={onEditClick} size="small" sx={iconInRowSx}>
+                                    <ClearIcon fontSize="inherit" />
+                                </IconButton>
+                            </>
+                        }
+                    />
+                )
             ) : EDIT_COL === colDesc.dfid ? (
                 deletion ? (
                     <Input


### PR DESCRIPTION
Easy to test (Tx to Dr Irv) :
```
import pandas as pd
from src.taipy.gui import Gui, State

df = pd.DataFrame({"x": [1, 2, 3], "flag": [True, False, True]})

def myedit(state: State, varname: str, action: str, payload: dict):
    temp_df = state.df.copy()
    temp_df.loc[payload["index"], payload["col"]] = payload["value"]
    state.df = temp_df

def printit(state: State):
    print(state.df)

page = """
# Table Bool editing 

<|{df}|table|height=max-content|width=max-content|show_all=True|on_edit=myedit|>

<|print|button|on_action=printit|>
"""


if __name__ == "__main__":
    Gui(page=page).run(async_mode="threading", use_relaoder=False)
```