### PR TITLE
do not define font-weight in typography (#486)

### DIFF
--- a/gui/src/components/Taipy/Field.tsx
+++ b/gui/src/components/Taipy/Field.tsx
@@ -50,7 +50,7 @@ const Field = (props: TaipyFieldProps) => {
                     {value}
                 </span>
             ) : (
-                <Typography className={className} id={id} component="span">
+                <Typography className={className} id={id} component="span" sx={{fontWeight: "unset"}}>
                     {value}
                 </Typography>
             )}

--- a/gui/src/components/Taipy/Field.tsx
+++ b/gui/src/components/Taipy/Field.tsx
@@ -27,6 +27,8 @@ interface TaipyFieldProps extends TaipyBaseProps, TaipyHoverProps {
     raw?: boolean;
 }
 
+const unsetWeightSx = {fontWeight: "unset"};
+
 const Field = (props: TaipyFieldProps) => {
     const { id, dataType, format, defaultValue, raw } = props;
     const formatConfig = useFormatConfig();
@@ -50,7 +52,7 @@ const Field = (props: TaipyFieldProps) => {
                     {value}
                 </span>
             ) : (
-                <Typography className={className} id={id} component="span" sx={{fontWeight: "unset"}}>
+                <Typography className={className} id={id} component="span" sx={unsetWeightSx}>
                     {value}
                 </Typography>
             )}


### PR DESCRIPTION
```
from taipy.gui import Gui, State

text = "red"

page = """
# md text styling

Text normal: <|{text}|>

Text italic: *<|{text}|>*

Text bold: **<|{text}|>**
"""

if __name__ == "__main__":
    Gui(page=page).run(async_mode="threading", use_relaoder=False)
```