### PR TITLE
Protect local files against unwanted access (#498)

### DIFF
--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -213,7 +213,9 @@ class Gui:
                 you want to access them using only '_assets_' in your application, you can
                 set _path_mapping={"assets": "/home/me/app_assets"}_. If your application
                 then requests the file _"/assets/images/logo.png"_, the server searches
-                for the file  _"/home/me/app_assets/images/logo.png"_.
+                for the file  _"/home/me/app_assets/images/logo.png"_.<br/>
+                If empty or not defined, access through the browser to all resources under the directory of the main python file
+                is allowed.
             env_filename (Optional[str]): An optional file from which to load application
                 configuration variables (see the
                 [Configuration](../gui/configuration.md#configuring-the-gui-instance) section

--- a/src/taipy/gui/server.py
+++ b/src/taipy/gui/server.py
@@ -124,6 +124,7 @@ class _Server:
                     return send_from_directory(base_path, path[len(k) + 1 :])
             if (
                 hasattr(__main__, "__file__")
+                and not self.__path_mapping
                 and str(
                     os.path.normpath(
                         file_path := ((base_path := os.path.dirname(__main__.__file__) + os.path.sep) + path)
@@ -132,7 +133,7 @@ class _Server:
                 and os.path.isfile(file_path)
             ):
                 return send_from_directory(base_path, path)
-            if str(os.path.normpath(file_path := (base_path := self._gui._root_dir + os.path.sep) + path)).startswith(
+            if not self.__path_mapping and str(os.path.normpath(file_path := (base_path := self._gui._root_dir + os.path.sep) + path)).startswith(
                 base_path
             ) and os.path.isfile(file_path):
                 return send_from_directory(base_path, path)


### PR DESCRIPTION
by default, every resource is accessible through the browser.
If path_mapping is specified and not empty, access is restricted.

```
import numpy as np
from taipy.gui import Gui
import pandas as pd

list_r = np.random.randint(1,50,500)
df = pd.DataFrame(list_r,columns=['value'])
options={"nbinsx": 5}
page = '''
# first page
<|{df}|chart|type=histogram|options={options}|>
'''

Gui(page=page, path_mapping={"toto": "1"}).run(async_mode="threading")
```
![image](https://user-images.githubusercontent.com/90181748/203607141-e6f45dd2-29ec-4603-bc67-61f085426091.png)


While with 
`Gui(page=page).run(async_mode="threading")
`
or
`Gui(page=page, path_mapping={}).run(async_mode="threading")
`![image](https://user-images.githubusercontent.com/90181748/203607397-2d4173c1-2b14-4faa-a753-06e3091d8288.png)
