### PR TITLE
#549 shorter syntax for indexed properties

### DIFF
--- a/gui/doc/chart.md
+++ b/gui/doc/chart.md
@@ -12,6 +12,9 @@ specify which trace you target.
 Indexed properties can have a default value (using the *property_name* syntax with
 no index) which is overridden by any specified indexed property.
 
+Indexed properties can also be declared as a list associated to the default property (*property_name* syntax with
+no index).
+
 The _data_ property supported types are:
 
 - pandas Dataframe

--- a/src/taipy/gui/renderers/builder.py
+++ b/src/taipy/gui/renderers/builder.py
@@ -567,6 +567,17 @@ class _Builder:
             trace[_Chart_iprops.xaxis.value] = "x"
         if not trace[_Chart_iprops.yaxis.value]:
             trace[_Chart_iprops.yaxis.value] = "y"
+        # Indexed properties: Check for arrays
+        for prop in _Chart_iprops:
+            values = trace[prop.value]
+            if isinstance(values, (list, tuple)) and len(values):
+                for idx, val in enumerate(values):
+                    if idx == 0:
+                        trace[prop.value] = val
+                    if val is not None:
+                        indexed_prop = f"{prop.name}[{idx + 1}]"
+                        if self.__attributes.get(indexed_prop) is None:
+                            self.__attributes[indexed_prop] = val
         # marker selected_marker options
         self.__check_dict(trace, (_Chart_iprops.marker, _Chart_iprops.selected_marker, _Chart_iprops.options))
         axis = []
@@ -696,13 +707,6 @@ class _Builder:
             self._set_chart_selected(max=len(traces))
             self.__set_refresh_on_update()
         return self
-
-    def _set_chart_layout(self):
-        if layout := self.__attributes.get("layout"):
-            if isinstance(layout, (dict, _MapDict)):
-                self.__set_json_attribute("layout", layout)
-            else:
-                warnings.warn(f"Chart control: layout attribute should be a dict\n'{str(layout)}'")
 
     def _set_string_with_check(self, var_name: str, values: t.List[str], default_value: t.Optional[str] = None):
         value = self.__attributes.get(var_name, default_value)

--- a/tests/taipy/gui/control/test_chart.py
+++ b/tests/taipy/gui/control/test_chart.py
@@ -10,6 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 import inspect
+import random
+import datetime
+import typing as t
 
 from taipy.gui import Gui
 
@@ -154,3 +157,57 @@ def test_map_md(gui: Gui, helpers):
         'updateVarName="_TpD_tpec_TpExPr_mapData_TPMDL_0"',
     ]
     helpers.test_control_md(gui, md, expected_list)
+
+def test_chart_indexed_properties(gui: Gui, helpers):
+    data: t.Dict[str, t.Any] = {}
+    data["Date"] = [datetime.datetime(2021, 12, i) for i in range(1, 31)]
+
+    data["La Rochelle"] = [10 + 6 * random.random() for _ in range(1, 31)]
+    data["Montpellier"] = [16 + 6 * random.random() for _ in range(1, 31)]
+    data["Paris"] = [6 + 6 * random.random() for _ in range(1, 31)]
+
+    data["La Rochelle 1"] = [x * (1 + (random.random() / 10)) for x in data["La Rochelle"]]
+    data["La Rochelle 2"] = [x * (1 - (random.random() / 10)) for x in data["La Rochelle"]]
+
+    data["Montpellier 1"] = [x * (1 + (random.random() / 10)) for x in data["Montpellier"]]
+    data["Montpellier 2"] = [x * (1 - (random.random() / 10)) for x in data["Montpellier"]]
+
+    md = "<|{data}|chart|x=Date|mode=lines|y[1]=La Rochelle|y[2]=La Rochelle 1|y[3]=La Rochelle 2|y[4]=Montpellier|y[5]=Montpellier 1|y[6]=Montpellier 2|line[2]=dashdot|line[3]=dash|line[5]=dashdot|line[6]=dash|color[2]=blue|color[3]=blue|color[5]=red|color[6]=red|>"
+
+    gui._set_frame(inspect.currentframe())
+    expected_list = [
+        "<Chart",
+        '&quot;traces&quot;: [[&quot;Date_str&quot;, &quot;La Rochelle&quot;], [&quot;Date_str&quot;, &quot;La Rochelle 1&quot;], [&quot;Date_str&quot;, &quot;La Rochelle 2&quot;], [&quot;Date_str&quot;, &quot;Montpellier&quot;], [&quot;Date_str&quot;, &quot;Montpellier 1&quot;], [&quot;Date_str&quot;, &quot;Montpellier 2&quot;]]',
+        '&quot;lines&quot;: [null, &#x7B;&quot;dash&quot;: &quot;dashdot&quot;&#x7D;, &#x7B;&quot;dash&quot;: &quot;dash&quot;&#x7D;, null, &#x7B;&quot;dash&quot;: &quot;dashdot&quot;&#x7D;, &#x7B;&quot;dash&quot;: &quot;dash&quot;&#x7D;]',
+    ]
+    helpers.test_control_md(gui, md, expected_list)
+
+
+def test_chart_indexed_properties_with_arrays(gui: Gui, helpers):
+    data: t.Dict[str, t.Any] = {}
+    data["Date"] = [datetime.datetime(2021, 12, i) for i in range(1, 31)]
+
+    data["La Rochelle"] = [10 + 6 * random.random() for _ in range(1, 31)]
+    data["Montpellier"] = [16 + 6 * random.random() for _ in range(1, 31)]
+    data["Paris"] = [6 + 6 * random.random() for _ in range(1, 31)]
+
+    data["La Rochelle 1"] = [x * (1 + (random.random() / 10)) for x in data["La Rochelle"]]
+    data["La Rochelle 2"] = [x * (1 - (random.random() / 10)) for x in data["La Rochelle"]]
+
+    data["Montpellier 1"] = [x * (1 + (random.random() / 10)) for x in data["Montpellier"]]
+    data["Montpellier 2"] = [x * (1 - (random.random() / 10)) for x in data["Montpellier"]]
+
+    ys = ["La Rochelle", "La Rochelle 1", "La Rochelle 2", "Montpellier", "Montpellier 1", "Montpellier 2"]
+    lines = [None, "dashdot", "dash", None, "dashdot", "dash"]
+    colors = [None, "blue", "blue", None, "red", "red"]
+
+    md = "<|{data}|chart|x=Date|mode=lines|y={ys}|line={lines}|color={colors}|>"
+
+    gui._set_frame(inspect.currentframe())
+    expected_list = [
+        "<Chart",
+        '&quot;traces&quot;: [[&quot;Date_str&quot;, &quot;La Rochelle&quot;], [&quot;Date_str&quot;, &quot;La Rochelle 1&quot;], [&quot;Date_str&quot;, &quot;La Rochelle 2&quot;], [&quot;Date_str&quot;, &quot;Montpellier&quot;], [&quot;Date_str&quot;, &quot;Montpellier 1&quot;], [&quot;Date_str&quot;, &quot;Montpellier 2&quot;]]',
+        '&quot;lines&quot;: [null, &#x7B;&quot;dash&quot;: &quot;dashdot&quot;&#x7D;, &#x7B;&quot;dash&quot;: &quot;dash&quot;&#x7D;, null, &#x7B;&quot;dash&quot;: &quot;dashdot&quot;&#x7D;, &#x7B;&quot;dash&quot;: &quot;dash&quot;&#x7D;]',
+    ]
+    helpers.test_control_md(gui, md, expected_list)
+


### PR DESCRIPTION
```
from taipy.gui import Gui, State

data = [
    {
        "r": [0, 1.5, 1.5, 0, 2.5, 2.5, 0],
        "theta": [0, 10, 25, 0, 205, 215, 0]},
    {
        "r": [0, 3.5, 3.5, 0],
        "theta": [0, 55, 75, 0]},
    {
        "r": [0, 4.5, 4.5, 0, 4.5, 4.5, 0],
        "theta": [0, 100, 120, 0, 305, 320, 0]},
    {
        "r": [0, 4, 4, 0],
        "theta": [0, 165, 195, 0]},
    {
        "r": [0, 3, 3, 0],
        "theta": [0, 262.5, 277.5, 0]},
]

options = [{"fill": "toself", "fillcolor": "#709BFF"},
  {"fill": "toself", "fillcolor": "#E4FF87"},
  {"fill": "toself", "fillcolor": "#FFAA70"},
  {"fill": "toself", "fillcolor": "#FFDF70"},
  {"fill": "toself", "fillcolor": "#B6FFB4"}]
line = {"color": "black"}

rs = [f"{i}/r" for i in range(len(data))]
thetas = [f"{i}/theta" for i in range(len(data))]

layout = {
    "polar": {
        "radialaxis": {
            "visible": True,
            "range": [0, 5]
        }
    },
    "showlegend": False
}

md = """
# Area Polar Chart

<|{data}|chart|type=scatterpolar|mode=lines|layout={layout}|line={line}|r={rs}|theta={thetas}|options={options}|>

"""

a_gui = Gui(md)
a_gui.run()

```