### PR TITLE
path_mapping change to support plotly (and other HTML content)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 exclude: 'tools/'
 repos:
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.910'  # Use the sha / tag you want to point at
+    rev: 'v0.991'  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
         additional_dependencies: [
@@ -58,7 +58,7 @@ repos:
     - id: black
       args: [--line-length=120]
       language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8


### PR DESCRIPTION
I wanted to find a way to get a plotly chart into the application.  So I did a hack to `taipy/gui/server.py` that works as follows:

1. In the `path_mapping argument to `Gui`, instead of mapping a path to a directory, you can map a path to a callable.  The callable should have the signature `my_callable(state: State, path: str) -> BytesIO`
2. The callable can return any HTML content in an open `BytesIO` object  that is dynamically generated, including content that has Javascript inside.
3. You can then create an HTML `iframe` that references the path prefix, and it should have as its last component the ID of the state (obtained via `get_state_id()`.  If you want the content to be truly dynamic, the `src` URL in `<iframe>` needs to change (otherwise the browser caches it), so you can use a `partial` that returns the `iframe` with an updated `src` URL.

Obviously, this technique would need to be documented, or maybe you want to use it as a starting point to support Plotly (or other dynamic HTML) content.  I have no idea what kind of tests should be used to test this feature.

I should note that I couldn't figure out how to just convert the HTML from plotly into XHTML, because the plotly HTML has Javascript inside, and that can't be parsed due to the presence of things like "<" and "&" (and maybe other characters)

I'm open to discussion if there are other things you'd like me to do to this.  Or maybe you have an alternate solution.  And I might be missing something with respect to whether this would work in a mutli-session context.

Here is an example that you can run using this PR (expand the details):

<details>

```python
from datetime import timedelta
from datetime import datetime as dt
import time
from io import BytesIO


from taipy.gui import Gui, Html, State, get_state_id
import plotly.express as px
from plotly.io import to_html

# This will contain the string of HTML that will be the source included in the
# iframe
html_out = "placeholder"

# This is the default height.  It's also possible to parse the height out of the
# generated HTML using BeautifulSoup (or can get it from the plotly figure)
DEFAULT_HEIGHT = "500px"

# We will illustrate that changing this value changes the plot
curval = 3

# This is the last time that an update was done
last_update = dt.now()

# This indicates whether the first graph has appeared.
initialized = False


def dynamic_file_name(state: State) -> str:
    # This is the name of the source referenced in the iframe.
    # The prefix "plotly" is used in the path_mapper
    # Note that the URL has to have a "." in it due to how taipy works
    # The URL has the current date/time to force the browser to not cache
    # The final segment of the URL is the ID of the state
    return (
        "plotly/plotly.htm/"
        + dt.now().strftime("%Y%m%d%H%M%S%f")
        + "/"
        + f"{get_state_id(state)}"
    )


def get_fig_html(curval: int) -> str:
    # This can be any Plotly graph.  Note that the parameters
    fig = px.line(x=["a", "b", "c"], y=[1, curval, 2], title=f"sample figure {curval}")
    # The parameters `include_plotlyjs="cdn"` tell Plotly to have a reference in the
    # HTML to download the plotly javascript.  The `full_html=False` tells plotly that we
    # just need a "<div>" to embed - not a full page, since it will go in an <iframe>
    html_plotly = to_html(fig, include_plotlyjs="cdn", full_html=False, default_height=DEFAULT_HEIGHT)  # type: ignore
    return html_plotly


def update_fig(state: State, vname: str, value: int):
    state.curval = value

    state.html_out = get_fig_html(value)

    # There is a timing issue, so if we were asked to update the figure within 0.5 seconds
    # we wait to do the update
    curtime = dt.now()
    difftime: timedelta = curtime - state.last_update
    if difftime < timedelta(seconds=0.5):
        time.sleep(0.5)

    filename = dynamic_file_name(state)

    height = DEFAULT_HEIGHT

    # Here is where we create the iframe that taipy will insert, with our dynamically
    # created filename
    html_string = f'<iframe src="/{filename}" height="{height}" width="100%" style="border:none;" scrolling="no"></iframe>'

    state.last_update = curtime
    state.partial.update_content(state, html_string)


def get_fig_fp(state: State, path: str) -> BytesIO:

    # This simple function just has to put the content into `BytesIO` .  The
    # server will call this function, passing the state so that a reference to
    # the dynamic content can be passed back to the server
    output = BytesIO()
    output.write(bytes(state.html_out, "utf-8"))

    return output


def on_navigate(state: State, page_name: str) -> str:
    # This is needed so the initial graph appears, but just once, since
    # on_navigate gets called multiple times.
    if not state.initialized:
        update_fig(state, "curval", state.curval)
    state.initialized = True
    return page_name


# The page will have a slider the user can change, a text field showing the value
# and the chart

page = """## Test

<|{curval}|slider|min=0|max=100|on_change=update_fig|>

Current Value: <|{curval}|>

<|part|partial={partial}|>

"""

# Note the use of `path_mapping` here to map any URL with "plotly" as the directory
# to our function to be called to provide that content.
gui = Gui(path_mapping={"plotly": get_fig_fp})
gui.add_page("main", page)
partial = gui.add_partial(Html("placeholder"))

gui.run(
    async_mode="threading",
    title="pathmap Demo",
    debug=True,
    use_reloader=True,
)
```

</details>

Here's the resulting display:
![image](https://user-images.githubusercontent.com/15113894/216460871-82e6277c-b109-4556-9b83-9b325adf43f6.png)

