### PR TITLE
Documentation for the Stylekit (part 1)

### DIFF
--- a/doc/extension/example_library/front-end/tsconfig.json
+++ b/doc/extension/example_library/front-end/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
     "outDir": "./dist/",
     "sourceMap": true,
     "allowJs": true,

--- a/gui/doc/button.md
+++ b/gui/doc/button.md
@@ -1,8 +1,52 @@
 A control that can trigger a function when pressed.
 
+## Styling
+
+All the button controls are generated with the "taipy-button" CSS class. You can use this class
+name to select the buttons on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides specific classes that you can use to style buttons:
+
+* *secondary*<br/>*error*<br/>*warning*<br/>*success*<br/>
+    Buttons are normally displayed using the value of the *color_primary* Stylekit variable.
+    These classes can be used to change the color used to draw the button, respectively, with
+    the *color_secondary*, *color_error*, *color_warning* and *color_success* Stylekit variable
+    values.
+
+    The Markdown content: 
+    ```
+    <|Error|button|class_name=error|><|Secondary|button|class_name=secondary|>
+    ```
+
+    Renders like this:
+    <figure>
+      <img src="../button-stylekit_color-d.png" class="visible-dark" />
+      <img src="../button-stylekit_color-l.png" class="visible-light"/>
+      <figcaption>Using color classes</figcaption>
+    </figure>
+
+* *plain*<br/>
+    The button is filled with a plain color rather than just outlined.
+
+    The Markdown content: 
+    ```
+    <|Button 1|button|><|Button 2|button|class_name=plain|>
+    ```
+
+    Renders like this:
+    <figure>
+        <img src="../button-stylekit_plain-d.png" class="visible-dark" />
+        <img src="../button-stylekit_plain-l.png" class="visible-light"/>
+        <figcaption>Using the <code>plain</code> class</figcaption>
+    </figure>
+
+* *fullwidth*: The button is rendered on its own line and expands across the entire available width.
+
 ## Usage
 
-### Simple text
+### Simple button
 
 The button label, which is the button control's default property, is simply displayed as the button
 text.
@@ -20,6 +64,12 @@ text.
         ```html
         <taipy:button>Button Label</taipy:button>
         ```
+
+<figure>
+    <img src="../button-simple-d.png" class="visible-dark" />
+    <img src="../button-simple-l.png" class="visible-light"/>
+    <figcaption>A simple button</figcaption>
+</figure>
 
 ### Specific action callback
 

--- a/gui/doc/chart.md
+++ b/gui/doc/chart.md
@@ -104,6 +104,30 @@ or slightly shorter (and if there are no more than three traces):
 page = "<|...|chart|...|i_property={value1}|i_property[2]={value2}|i_property[3]={value3}|...|>"
 ```
 
+## Styling
+
+All the chart controls are generated with the "taipy-chart" CSS class. You can use this class
+name to select the charts on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides a specific class that you can use to style charts:
+
+* *opaque-bg*<br/>
+    TODO.
+
+    The Markdown content: 
+    ```
+    TODO
+    ```
+
+    Renders like this:
+    <figure>
+      <img src="../chart-stylekit_opaque-bg-d.png" class="visible-dark" />
+      <img src="../chart-stylekit_opaque-bg-l.png" class="visible-light"/>
+      <figcaption>With and without the *opaque-bg* class*</figcaption>
+    </figure>
+
 ## Usage
 
 Here is a list of several sub-sections that you can check to get more details on a specific

--- a/gui/doc/chart.md
+++ b/gui/doc/chart.md
@@ -113,20 +113,10 @@ name to select the charts on your page and apply style.
 
 The [Stylekit](../styling/stylekit.md) provides a specific class that you can use to style charts:
 
-* *opaque-bg*<br/>
-    TODO.
-
-    The Markdown content: 
-    ```
-    TODO
-    ```
-
-    Renders like this:
-    <figure>
-      <img src="../chart-stylekit_opaque-bg-d.png" class="visible-dark" />
-      <img src="../chart-stylekit_opaque-bg-l.png" class="visible-light"/>
-      <figcaption>With and without the *opaque-bg* class*</figcaption>
-    </figure>
+* *has-background*<br/>
+    When the chart control uses the *has-background* class, the rendering of the chart
+    background is left to the charting library.<br/>
+    The default behavior is to render the chart transparently.
 
 ## Usage
 

--- a/gui/doc/date.md
+++ b/gui/doc/date.md
@@ -1,5 +1,10 @@
 A control that can display and specify a formatted date, with or without time.
 
+## Styling
+
+All the date controls are generated with the "taipy-date" CSS class. You can use this class
+name to select the date selectors on your page and apply style.
+
 ## Usage
 
 ### Using the full date and time

--- a/gui/doc/dialog.md
+++ b/gui/doc/dialog.md
@@ -3,6 +3,11 @@ A modal dialog.
 Dialog allows showing some content over the current page.
 The dialog is closed when the user presses the Cancel or Validate buttons, or clicks outside the area of the dialog (triggering a Cancel action).
 
+## Styling
+
+All the dialogs are generated with the "taipy-dialog" CSS class. You can use this class
+name to select the dialogs on your page and apply style.
+
 ## Usage
 
 ### Showing or hiding a dialog

--- a/gui/doc/expandable.md
+++ b/gui/doc/expandable.md
@@ -2,6 +2,11 @@ Displays its child elements in a collapsable area.
 
 Expandable is a block control.
 
+## Styling
+
+All the expandable blocks are generated with the "taipy-expandable" CSS class. You can use this class
+name to select the expandable blocks on your page and apply style.
+
 ## Usage
 
 ### Defining a title and managing expanded state

--- a/gui/doc/file_download.md
+++ b/gui/doc/file_download.md
@@ -10,6 +10,11 @@ Allows downloading of a file content.
     
 The download can be triggered when clicking on a button, or can be performed automatically.
 
+## Styling
+
+All the file download controls are generated with the "taipy-file_download" CSS class. You can use this class
+name to select the file download controls on your page and apply style.
+
 ## Usage
 
 ### Default behavior

--- a/gui/doc/file_selector.md
+++ b/gui/doc/file_selector.md
@@ -2,6 +2,11 @@ Allows uploading a file content.
 
 The upload can be triggered by pressing a button, or drag-and-dropping a file on top of the control.
 
+## Styling
+
+All the file selector controls are generated with the "taipy-file_selector" CSS class. You can use this class
+name to select the file selector controls on your page and apply style.
+
 ## Usage
 
 ### Default behavior

--- a/gui/doc/image.md
+++ b/gui/doc/image.md
@@ -9,6 +9,18 @@ A control that can display an image.
 
 You can indicate a function to be called when the user clicks on the image.
 
+## Styling
+
+All the image controls are generated with the "taipy-image" CSS class. You can use this class
+name to select the image controls on your page and apply style.
+
+The [Stylekit](../styling/stylekit.md) also provides a specific CSS class that you can use to style
+images:
+
+- *inline*<br/>
+  Displays an image as inline and vertically centered. It would otherwise be displayed as a block.
+  This can be relevant when dealing with SVG images.
+
 ## Usage
 
 ### Default behavior

--- a/gui/doc/indicator.md
+++ b/gui/doc/indicator.md
@@ -3,6 +3,11 @@ Displays a label on a red to green scale at a specific position.
 The _min_ value can be greater than the _max_ value.<br/>
 The value will be maintained between min and max.
 
+## Styling
+
+All the indicator controls are generated with the "taipy-indicator" CSS class. You can use this class
+name to select the indicator controls on your page and apply style.
+
 ## Usage
 
 ### Minimal usage

--- a/gui/doc/input.md
+++ b/gui/doc/input.md
@@ -1,5 +1,10 @@
 A control that displays some text that can potentially be edited.
 
+## Styling
+
+All the input controls are generated with the "taipy-input" CSS class. You can use this class
+name to select the input controls on your page and apply style.
+
 ## Usage
 
 ### Get user input

--- a/gui/doc/layout.md
+++ b/gui/doc/layout.md
@@ -4,6 +4,29 @@ The _columns_ property follows the [CSS standard](https://developer.mozilla.org/
 If the _columns_ property contains only digits and spaces, it is considered as flex-factor unit:
 "1 1" => "1fr 1fr"
 
+## Styling
+
+All the layout blocks are generated with the "taipy-layout" CSS class. You can use this class
+name to select the layout blocks on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides specific classes that you can use to style layout
+blocks:
+
+- *align-columns-top*<br/>
+  Aligns the content to the top of each column.
+- *align-columns-center*<br/>
+  Aligns the content to the center of each column.
+- *align-columns-bottom*<br/>
+  Aligns the content to the bottom of each column.
+- *align-columns-stretch*<br/>
+  Gives all columns the height of the highest column.
+
+Additional classes are defined for the [`part`](part.md) block element when inserted in
+a layout block. Please see the [section on styling](part.md#stylekit-support) for parts
+for more details.
+
 ## Usage
 
 ### Default layout

--- a/gui/doc/menu.md
+++ b/gui/doc/menu.md
@@ -2,6 +2,11 @@ Shows a left-side menu.
 
 This control is represented by a unique left-anchor and foldable vertical menu.
 
+## Styling
+
+All the menu controls are generated with the "taipy-menu" CSS class. You can use this class
+name to select the menu controls on your page and apply style.
+
 ## Usage
 
 ### Defining a simple static menu

--- a/gui/doc/navbar.md
+++ b/gui/doc/navbar.md
@@ -2,6 +2,18 @@ A navigation bar control.
 
 This control is implemented as a list of links.
 
+## Styling
+
+All the navbar controls are generated with the "taipy-navbar" CSS class. You can use this class
+name to select the navbar controls on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides a specific class that you can use to style navbar controls:
+
+* *fullheight*<br/>
+  Ensures the tabs fill the full height of their container (in a header bar for example).
+
 ## Usage
 
 ### Defining a default navbar

--- a/gui/doc/number.md
+++ b/gui/doc/number.md
@@ -1,5 +1,11 @@
 A kind of [`input`](input.md) that handles numbers.
 
+
+## Styling
+
+All the number controls are generated with the "taipy-number" CSS class. You can use this class
+name to select the number controls on your page and apply style.
+
 ## Usage
 
 ### Simple

--- a/gui/doc/pane.md
+++ b/gui/doc/pane.md
@@ -3,6 +3,13 @@ A side pane.
 Pane allows showing some content on top of the current page.
 The pane is closed when the user clicks outside the area of the pane (triggering a _on_close_ action).
 
+Pane is a block control.
+
+## Styling
+
+All the pane blocks are generated with the "taipy-pane" CSS class. You can use this class
+name to select the pane blocks on your page and apply style.
+
 ## Usage
 
 ### Showing or hiding a pane

--- a/gui/doc/part.md
+++ b/gui/doc/part.md
@@ -1,12 +1,40 @@
 Displays its children in a block.
 
-The `part` control is used to group controls in a single element.
+The `part` block is used to group visual elements in a single element.
 This allows to show or hide them in one action and be placed as a unique element in a [`Layout`](layout.md) cell.
 
 There is a simplified Markdown syntax to create a `part`, where the element name is optional:
 
 `<|` just before the end of the line indicates the beginning of a `part` element;
 `|>` at the beginning of a line indicated the end of the `part` definition.
+
+
+## Styling
+
+All the part blocks are generated with the "taipy-part" CSS class. You can use this class
+name to select the part blocks on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides specific classes that you can use to style part
+blocks:
+
+- *align-item-top*<br/>
+  If this part block is inside a [`layout`](layout.md) block, this CSS class aligns the part
+  content to the top the layout column it belongs to.
+- *align-item-center*<br/>
+  If this part block is inside a [`layout`](layout.md) block, this CSS class vertically aligns
+  the part content to the center of the layout column it belongs to.
+- *align-item-bottom*<br/>
+  If this part block is inside a [`layout`](layout.md) block, this CSS class vertically aligns
+  the part content to the bottom of the layout column it belongs to.
+- *align-item-stretch*<br/>
+  Give that column the same height as the highest one if different from it.<br/>
+  TODO - unclear
+
+
+TODO: predefine Stylekit classes for pane (container, header...)
+
 
 ## Usage
 

--- a/gui/doc/part.md
+++ b/gui/doc/part.md
@@ -29,12 +29,26 @@ blocks:
   If this part block is inside a [`layout`](layout.md) block, this CSS class vertically aligns
   the part content to the bottom of the layout column it belongs to.
 - *align-item-stretch*<br/>
-  Give that column the same height as the highest one if different from it.<br/>
-  TODO - unclear
+  If this part block is inside a [`layout`](layout.md) block, this CSS class 
+  gives the part the same height as the highest item in the row where this part
+  appears in the layout.
 
+The Stylekit also has several classes that can be used to style part blocks,
+as described in the [Styled Sections](../styling/stylekit.md#styled-sections)
+documentation.<br/>
+Because the default property of the *part* block is *class_name*, you can use the
+Markdown short syntax for parts:
 
-TODO: predefine Stylekit classes for pane (container, header...)
+```
+<|card|
+...
+  (card content)
+...
+|>
+```
 
+Creates a `part` that has the [*card*](../styling/stylekit.md#card) class defined
+in the Stylekit.
 
 ## Usage
 
@@ -46,9 +60,9 @@ TODO: predefine Stylekit classes for pane (container, header...)
 
         ```
         <|
-            ...
-            <|{Some Content}|>
-            ...
+        ...
+        <|{Some Content}|>
+        ...
         |>
         ```
 
@@ -56,9 +70,9 @@ TODO: predefine Stylekit classes for pane (container, header...)
 
         ```html
         <taipy:part>
-            ...
-            <taipy:text>{Some Content}</taipy:text>
-            ...
+        ...
+        <taipy:text>{Some Content}</taipy:text>
+        ...
         </taipy:part>
         ```
 
@@ -70,9 +84,9 @@ TODO: predefine Stylekit classes for pane (container, header...)
 
         ```
         <|part|don't render|
-            ...
-            <|{Some Content}|>
-            ...
+        ...
+        <|{Some Content}|>
+        ...
         |>
         ```
 
@@ -86,11 +100,29 @@ TODO: predefine Stylekit classes for pane (container, header...)
         </taipy:part>
         ```
 
-If the _render_ property is bound to a Boolean value, the `part` will show or hide its elements according to the value of the bound variable.
+If the *render* property is bound to a Boolean value, the `part` will show or hide its elements according to the value of the bound variable.
+
+### Styling parts
+
+The default property name of the `part` block is *class_name*. This allows for setting
+a CSS class to a `part` with a very simple Markdown syntax:
+
+!!! example "Markdown content"
+
+    ```
+    <|css-class|
+    ...
+    (part content)
+    ...
+    |>
+    ```
+
+This creates a `part` block that is applied the *css-class* CSS class defined in the
+application stylesheets.
 
 ### Part with page
 
-The content of the part can be specified as an existing page name or an URL using the _page_ property.
+The content of the part can be specified as an existing page name or an URL using the *page* property.
 
 !!! example "Page content"
 
@@ -108,7 +140,7 @@ The content of the part can be specified as an existing page name or an URL usin
 
 ### Part with partial
 
-The content of the part can be specified as a `Partial^` instance using the _partial_ property.
+The content of the part can be specified as a `Partial^` instance using the *partial* property.
 
 !!! example "Page content"
 

--- a/gui/doc/selector.md
+++ b/gui/doc/selector.md
@@ -8,6 +8,11 @@ A filtering feature is available to display only a subset of the items.
 
 You can use an arbitrary type for all the items (see the [example](#binding-to-a-list-of-objects)).
 
+## Styling
+
+All the selector controls are generated with the "taipy-selector" CSS class. You can use this class
+name to select the selector controls on your page and apply style.
+
 ## Usage
 
 ### Display a list of string

--- a/gui/doc/slider.md
+++ b/gui/doc/slider.md
@@ -4,6 +4,12 @@ The range is set by the values `min` and `max` which must be integer values.
 
 If the _lov_ property is used, then the slider can be used to select a value among the different choices.
 
+
+## Styling
+
+All the slider controls are generated with the "taipy-slider" CSS class. You can use this class
+name to select the sliders on your page and apply style.
+
 ## Usage
 
 ### Selecting a value between 0 and 100

--- a/gui/doc/status.md
+++ b/gui/doc/status.md
@@ -1,5 +1,9 @@
 Displays a status or a list of statuses.
 
+## Styling
+
+All the status controls are generated with the "taipy-status" CSS class. You can use this class
+name to select the status controls on your page and apply style.
 
 ## Usage
 

--- a/gui/doc/table.md
+++ b/gui/doc/table.md
@@ -34,9 +34,9 @@ tables:
 - *header-plain*<br/>
   Adds a plain and contrasting background color to the table header.
 - *rows-bordered*<br/>
-  Add a bottom border to each row.
+  Adds a bottom border to each row.
 - *rows-similar*<br/>
-  TODO
+  Removes the even-odd striped background so all rows have the same background.
 
 ## Usage
 

--- a/gui/doc/table.md
+++ b/gui/doc/table.md
@@ -14,6 +14,30 @@ The _data_ property supported types are:
 
 Data columns are accessed by their name or index (temporary dataframes are built from these different sources).
 
+
+## Styling
+
+All the table controls are generated with the "taipy-table" CSS class. You can use this class
+name to select the tables on your page and apply style.
+
+### [Stylekit](../styling/stylekit.md) support
+
+The [Stylekit](../styling/stylekit.md) provides a CSS custom property:
+
+- *--table-stripe-opacity*<br/>
+  This property contains the opacity applied to odd lines of tables.<br/>
+  The default value is 0.5.
+
+The [Stylekit](../styling/stylekit.md) also provides specific CSS classes that you can use to style
+tables:
+
+- *header-plain*<br/>
+  Adds a plain and contrasting background color to the table header.
+- *rows-bordered*<br/>
+  Add a bottom border to each row.
+- *rows-similar*<br/>
+  TODO
+
 ## Usage
 
 ### Show a table

--- a/gui/doc/text.md
+++ b/gui/doc/text.md
@@ -10,6 +10,11 @@ The _format_ property uses a format string like the ones used by the string _for
 If the value is a `date` or a `datetime`, then _format_ can be set to a date/time formatting string.
 
 
+## Styling
+
+All the text controls are generated with the "taipy-text" CSS class. You can use this class
+name to select the text controls on your page and apply style.
+
 ## Usage
 
 ### Display value

--- a/gui/doc/toggle.md
+++ b/gui/doc/toggle.md
@@ -6,6 +6,19 @@ Each button is represented by a string, an image or both.
 
 You can use an arbitrary type for all the items (see the [example](#use-arbitrary-objects)).
 
+## Styling
+
+All the toggle controls are generated with the "taipy-toggle" CSS class. You can use this class
+name to select the toggle controls on your page and apply style.
+
+The [Stylekit](../styling/stylekit.md) also provides specific CSS classes that you can use to style
+toggle controls:
+
+- *relative*<br/>
+  Resets the theme toggle position in the page flow (especially for the theme mode toggle).
+- *nolabel*<br/>
+  Hides the toggle control's label.
+
 ## Usage
 
 ### Display a list of string

--- a/gui/doc/tree.md
+++ b/gui/doc/tree.md
@@ -8,6 +8,12 @@ A filtering feature is available to display only a subset of the items.
 
 You can use an arbitrary type for all the items (see the [example](#binding-to-a-list-of-objects)).
 
+
+## Styling
+
+All the tree controls are generated with the "taipy-tree" CSS class. You can use this class
+name to select the tree controls on your page and apply style.
+
 ## Usage
 
 ### Display a list of string

--- a/gui/public/stylekit/base/typography.css
+++ b/gui/public/stylekit/base/typography.css
@@ -64,14 +64,14 @@ h6,
     font-size: var(--font-size-h6);
 }
 
-.text_body {
+.text-body {
     font-size: var(--font-size-body);
 }
 
-.text_small {
+.text-small {
     font-size: var(--font-size-small);
 }
 
-.text_caption {
+.text-caption {
     font-size: var(--font-size-caption);
 }

--- a/gui/public/stylekit/blocks/layout.css
+++ b/gui/public/stylekit/blocks/layout.css
@@ -29,8 +29,8 @@
     min-width: 0;
 }
 
-.taipy-layout.align_columns_stretch>.taipy-part>.md-para,
-.taipy-layout>.taipy-part.align_item_stretch>.md-para {
+.taipy-layout.align-columns-stretch>.taipy-part>.md-para,
+.taipy-layout>.taipy-part.align-item-stretch>.md-para {
     height: 100%;
 }
 
@@ -40,44 +40,44 @@
 
 /***** Assignable to the layout block *****/
 
-/* align_columns_top: vertically align every column's content to the top of the line  */
-.taipy-layout.align_columns_top {
+/* align-columns-top: vertically align every column's content to the top of the line  */
+.taipy-layout.align-columns-top {
     align-items: start;
 }
 
-/* align_columns_center: vertically align every column's content to the center of the line  */
-.taipy-layout.align_columns_center {
+/* align-columns-center: vertically align every column's content to the center of the line  */
+.taipy-layout.align-columns-center {
     align-items: center;
 }
 
-/* align_columns_bottom: vertically align every column's content to the bottom of the line  */
-.taipy-layout.align_columns_bottom {
+/* align-columns-bottom: vertically align every column's content to the bottom of the line  */
+.taipy-layout.align-columns-bottom {
     align-items: end;
 }
 
-/* align_columns_stretch: stretch every column's content to fill the whole height of the line  */
-.taipy-layout.align_columns_stretch {
+/* align-columns-stretch: stretch every column's content to fill the whole height of the line  */
+.taipy-layout.align-columns-stretch {
     align-items: stretch;
 }
 
 /***** Assignable to the layout children parts *****/
 
-/* align_item_top: vertically align this column's content to the top of the line  */
-.taipy-part.align_item_top {
+/* align-item-top: vertically align this column's content to the top of the line  */
+.taipy-part.align-item-top {
     align-self: start;
 }
 
-/* align_item_center: vertically align this column's content to the center of the line  */
-.taipy-part.align_item_center {
+/* align-item-center: vertically align this column's content to the center of the line  */
+.taipy-part.align-item-center {
     align-self: center;
 }
 
-/* align_item_bottom: vertically align this column's content to the bottom of the line  */
-.taipy-part.align_item_bottom {
+/* align-item-bottom: vertically align this column's content to the bottom of the line  */
+.taipy-part.align-item-bottom {
     align-self: end;
 }
 
-/* align_item_stretch: stretch this column's content to fill the whole height of the line  */
-.taipy-part.align_item_stretch {
+/* align-item-stretch: stretch this column's content to fill the whole height of the line  */
+.taipy-part.align-item-stretch {
     align-self: stretch;
 }

--- a/gui/public/stylekit/controls/chart.css
+++ b/gui/public/stylekit/controls/chart.css
@@ -37,7 +37,7 @@
               UTILITY CLASSES
 **************************************************/
 
-/* .svg_bg: keep the original svg background */
-.taipy-chart:not(.svg_bg) .main-svg {
+/* .opaque-bg: keep the original background */
+.taipy-chart:not(.opaque-bg) .main-svg {
   background: transparent !important;
 }

--- a/gui/public/stylekit/controls/table.css
+++ b/gui/public/stylekit/controls/table.css
@@ -40,26 +40,26 @@
 **************************************************/
 
 /* Soft header on rows as Stylekit default */
-/* "header_plain" class to return to MUI default plain header */
-.taipy-table:where(:not(.header_plain)) thead th {
+/* "header-plain" class to return to MUI default plain header */
+.taipy-table:where(:not(.header-plain)) thead th {
   background: var(--color-paper);
   font-weight: bold;
 }
 
 /* No borders on rows as Stylekit default */
-/* "rows_bordered" class to return to MUI default rows with borders */
-.taipy-table:where(:not(.rows_bordered)) thead th,
-.taipy-table:where(:not(.rows_bordered)) tbody td {
+/* "rows-bordered" class to return to MUI default rows with borders */
+.taipy-table:where(:not(.rows-bordered)) thead th,
+.taipy-table:where(:not(.rows-bordered)) tbody td {
   border-bottom: none;
 }
 
 /* Striped rows as Stylekit default */
-/* "rows_similar" to return to MUI default similar looking rows */
-.taipy-table:where(:not(.rows_similar)) tbody tr:nth-child(odd) {
+/* "rows-similar" to return to MUI default similar looking rows */
+.taipy-table:where(:not(.rows-similar)) tbody tr:nth-child(odd) {
   position: relative;
   z-index: 0;
 }
-.taipy-table:where(:not(.rows_similar)) tbody tr:nth-child(odd)::after {
+.taipy-table:where(:not(.rows-similar)) tbody tr:nth-child(odd)::after {
   content: '';
   position: absolute;
   top: 0;

--- a/gui/public/stylekit/utilities/colors.css
+++ b/gui/public/stylekit/utilities/colors.css
@@ -21,59 +21,59 @@
               TEXT COLOR
 **************************************************/
 
-.color_primary {
+.color-primary {
     color: var(--color-primary) !important;
 }
 
-.color_secondary {
+.color-secondary {
     color: var(--color-secondary) !important;
 }
 
-.color_error {
+.color-error {
     color: var(--color-error) !important;
 }
 
-.color_warning {
+.color-warning {
     color: var(--color-warning) !important;
 }
 
-.color_success {
+.color-success {
     color: var(--color-success) !important;
 }
 
-.color_background_light {
+.color-background-light {
     color: var(--color-background-light) !important;
 }
 
-.color_background_dark {
+.color-background-dark {
     color: var(--color-background-dark) !important;
 }
 
-.color_background {
+.color-background {
     color: var(--color-background) !important;
 }
 
-.color_paper_light {
+.color-paper-light {
     color: var(--color-paper-light) !important;
 }
 
-.color_paper_dark {
+.color-paper-dark {
     color: var(--color-paper-dark) !important;
 }
 
-.color_paper {
+.color-paper {
     color: var(--color-paper) !important;
 }
 
-.color_contrast_light {
+.color-contrast-light {
     color: var(--color-contrast-light) !important;
 }
 
-.color_contrast_dark {
+.color-contrast-dark {
     color: var(--color-contrast-dark) !important;
 }
 
-.color_contrast {
+.color-contrast {
     color: var(--color-contrast) !important;
 }
 
@@ -82,58 +82,58 @@
               BACKGROUND COLOR
 **************************************************/
 
-.bg_primary {
+.bg-primary {
     background-color: var(--color-primary) !important;
 }
 
-.bg_secondary {
+.bg-secondary {
     background-color: var(--color-secondary) !important;
 }
 
-.bg_error {
+.bg-error {
     background-color: var(--color-error) !important;
 }
 
-.bg_warning {
+.bg-warning {
     background-color: var(--color-warning) !important;
 }
 
-.bg_success {
+.bg-success {
     background-color: var(--color-success) !important;
 }
 
-.bg_default_light {
+.bg-default-light {
     background-color: var(--color-background-light) !important;
 }
 
-.bg_default_dark {
+.bg-default-dark {
     background-color: var(--color-background-dark) !important;
 }
 
-.bg_default {
+.bg-default {
     background-color: var(--color-background) !important;
 }
 
-.bg_paper_light {
+.bg-paper-light {
     background-color: var(--color-paper-light) !important;
 }
 
-.bg_paper_dark {
+.bg-paper-dark {
     background-color: var(--color-paper-dark) !important;
 }
 
-.bg_paper {
+.bg-paper {
     background-color: var(--color-paper) !important;
 }
 
-.bg_contrast_light {
+.bg-contrast-light {
     background-color: var(--color-contrast-light) !important;
 }
 
-.bg_contrast_dark {
+.bg-contrast-dark {
     background-color: var(--color-contrast-dark) !important;
 }
 
-.bg_contrast {
+.bg-contrast {
     background-color: var(--color-contrast) !important;
 }

--- a/gui/public/stylekit/utilities/spacing.css
+++ b/gui/public/stylekit/utilities/spacing.css
@@ -25,11 +25,11 @@
     margin: 0 !important;
 }
 
-.m_auto {
+.m-auto {
     margin: auto !important;
 }
 
-.m_half {
+.m-half {
     margin: var(--spacing-half) !important;
 }
 
@@ -61,11 +61,11 @@
     margin-top: 0 !important;
 }
 
-.mt_auto {
+.mt-auto {
     margin-top: auto !important;
 }
 
-.mt_half {
+.mt-half {
     margin-top: var(--spacing-half) !important;
 }
 
@@ -97,11 +97,11 @@
     margin-bottom: 0 !important;
 }
 
-.mb_auto {
+.mb-auto {
     margin-bottom: auto !important;
 }
 
-.mb_half {
+.mb-half {
     margin-bottom: var(--spacing-half) !important;
 }
 
@@ -133,11 +133,11 @@
     margin-left: 0 !important;
 }
 
-.ml_auto {
+.ml-auto {
     margin-left: auto !important;
 }
 
-.ml_half {
+.ml-half {
     margin-left: var(--spacing-half) !important;
 }
 
@@ -169,11 +169,11 @@
     margin-right: 0 !important;
 }
 
-.mr_auto {
+.mr-auto {
     margin-right: auto !important;
 }
 
-.mr_half {
+.mr-half {
     margin-right: var(--spacing-half) !important;
 }
 
@@ -209,7 +209,7 @@
     padding: 0 !important;
 }
 
-.p_half {
+.p-half {
     padding: var(--spacing-half) !important;
 }
 
@@ -241,7 +241,7 @@
     padding-top: 0 !important;
 }
 
-.pt_half {
+.pt-half {
     padding-top: var(--spacing-half) !important;
 }
 
@@ -273,7 +273,7 @@
     padding-bottom: 0 !important;
 }
 
-.pb_half {
+.pb-half {
     padding-bottom: var(--spacing-half) !important;
 }
 
@@ -305,7 +305,7 @@
     padding-left: 0 !important;
 }
 
-.pl_half {
+.pl-half {
     padding-left: var(--spacing-half) !important;
 }
 

--- a/gui/public/stylekit/utilities/typography.css
+++ b/gui/public/stylekit/utilities/typography.css
@@ -17,58 +17,58 @@
 
 ***************************************************************/
 
-.text_weight300 {
+.text-weight300 {
     font-weight: 300 !important;
 }
 
-.text_weight400 {
+.text-weight400 {
     font-weight: 400 !important;
 }
 
-.text_weight500 {
+.text-weight500 {
     font-weight: 500 !important;
 }
 
-.text_weight600 {
+.text-weight600 {
     font-weight: 600 !important;
 }
 
-.text_weight700 {
+.text-weight700 {
     font-weight: 700 !important;
 }
 
-.text_weight800 {
+.text-weight800 {
     font-weight: 800 !important;
 }
 
-.text_weight900 {
+.text-weight900 {
     font-weight: 900 !important;
 }
 
-.text_left {
+.text-left {
     text-align: left !important;
 }
 
-.text_center {
+.text-center {
     text-align: center !important;
 }
 
-.text_right {
+.text-right {
     text-align: right !important;
 }
 
-.text_uppercase {
+.text-uppercase {
     text-transform: uppercase !important;
 }
 
-.text_no_transform {
+.text-no-transform {
     text-transform: none !important;
 }
 
-.text_underline {
+.text-underline {
     text-decoration: underline !important;
 }
 
-.text_no_underline {
+.text-no-underline {
     text-decoration: none !important;
 }

--- a/gui/src/utils/index.ts
+++ b/gui/src/utils/index.ts
@@ -22,14 +22,14 @@ declare global {
             themes: Record<string, Record<string, unknown>>;
             timeZone: string;
             extensions: Record<string, string[]>;
-            stylekit?: StyleKitVars;
+            stylekit?: StyleKit;
         };
         taipyVersion: string;
         [key: string]: unknown;
     }
 }
 
-interface StyleKitVars {
+interface StyleKit {
     // Primary and secondary colors
     colorPrimary: string;
     colorSecondary: string;

--- a/src/taipy/gui/_default_config.py
+++ b/src/taipy/gui/_default_config.py
@@ -9,8 +9,38 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from .config import Config
+from .config import Config, Stylekit
 
+_default_stylekit: Stylekit = {
+    # Primary and secondary colors
+    "color_primary": "#ff6049",
+    "color_secondary": "#293ee7",
+
+    # Contextual color
+    "color_error": "#FF595E",
+    "color_warning": "#FAA916",
+    "color_success": "#96E6B3",
+
+    # Background and elevation color for LIGHT MODE
+    "color_background_light": "#f0f5f7",
+    "color_paper_light": "#ffffff",
+
+    # Background and elevation color for DARK MODE
+    "color_background_dark": "#152335",
+    "color_paper_dark": "#1f2f44",
+
+    # DEFINING FONTS
+    # Set main font family
+    "font_family": "Lato, Arial, sans-serif",
+
+    # DEFINING SHAPES
+    # Base border radius in px
+    "border_radius": 8,
+
+    # DEFINING MUI COMPONENTS STYLES
+    # Matching input and button height in css size unit
+    "input_button_height": "48px"
+}
 
 # Default config loaded by app.py
 default_config: Config = {
@@ -38,37 +68,7 @@ default_config: Config = {
     "theme": None,
     "time_zone": None,
     "title": None,
-    "stylekit": True,
-    "stylekit_variables" : {
-        # Primary and secondary colors
-        "color_primary": "#ff6049",
-        "color_secondary": "#293ee7",
-
-        # Contextual color
-        "color_error": "#FF595E",
-        "color_warning": "#FAA916",
-        "color_success": "#96E6B3",
-
-        # Background and elevation color for LIGHT MODE
-        "color_background_light": "#f0f5f7",
-        "color_paper_light": "#ffffff",
-
-        # Background and elevation color for DARK MODE
-        "color_background_dark": "#152335",
-        "color_paper_dark": "#1f2f44",
-
-        # DEFINING FONTS
-        # Set main font family
-        "font_family": "Lato, Arial, sans-serif",
-
-        # DEFINING SHAPES
-        # Base border radius in px
-        "border_radius": 8,
-
-        # DEFINING MUI COMPONENTS STYLES
-        # Matching input and button height in css size unit
-        "input_button_height": "48px"
-    },
+    "stylekit": _default_stylekit,
     "upload_folder": None,
     "use_arrow": False,
     "use_reloader": False,

--- a/src/taipy/gui/config.py
+++ b/src/taipy/gui/config.py
@@ -54,7 +54,6 @@ ConfigParameter = t.Literal[
     "time_zone",
     "title",
     "stylekit",
-    "stylekit_variables",
     "upload_folder",
     "use_arrow",
     "use_reloader",
@@ -63,8 +62,8 @@ ConfigParameter = t.Literal[
     "port",
 ]
 
-StylekitVariables = t.TypedDict(
-    "StylekitVariables",
+Stylekit = t.TypedDict(
+    "Stylekit",
     {
         "color_primary": str,
         "color_secondary": str,
@@ -110,8 +109,7 @@ Config = t.TypedDict(
         "theme": t.Optional[t.Dict[str, t.Any]],
         "time_zone": t.Optional[str],
         "title": t.Optional[str],
-        "stylekit": bool,
-        "stylekit_variables": StylekitVariables,
+        "stylekit": t.Union[bool, Stylekit],
         "upload_folder": t.Optional[str],
         "use_arrow": bool,
         "use_reloader": bool,
@@ -204,6 +202,11 @@ class _Config(object):
         for key, value in kwargs.items():
             key = key.lower()
             if value is not None and key in config:
+                # Special case for "stylekit" that can be a Boolean or a dict
+                if key == "stylekit" and isinstance(value, bool):
+                    from ._default_config import _default_stylekit
+                    config[key] = _default_stylekit if value else {}
+                    continue
                 try:
                     if isinstance(value, dict) and isinstance(config[key], dict):
                         config[key].update(value)

--- a/src/taipy/gui/extension/library.py
+++ b/src/taipy/gui/extension/library.py
@@ -343,13 +343,24 @@ class ElementLibrary(ABC):
 
     def on_init(self, gui: "Gui") -> t.Optional[t.Tuple[str, t.Any]]:
         """
-        TODO
-        Called by `Gui.run()^`.
+        Initialize this element library.
+
+        This method is invoked by `Gui.run()^`.
+
+        It allows to define variables that are accessible from elements
+        defined in this element library.
 
         Arguments
             gui: The `Gui^` instance.
 
         Returns:
-            An optional Tuple composed of a unique name for the library (that *must* be a valid Python identifier) and it's value
+            An optional tuple composed of a variable name (that *must* be a valid Python
+            identifier), associated with its value.<br/>
+            This name can be used as the name of a variable accessible by the elements defined
+            in this library.<br/>
+            This name must be unique across the entire application, which is a problem since
+            different element libraries might use the same symbol. A good development practice
+            is to make this variable name unique by prefixing it with the name of the element
+            library itself.
         """
         return None

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -39,7 +39,7 @@ from taipy.logger._taipy_logger import _TaipyLogger
 if util.find_spec("pyngrok"):
     from pyngrok import ngrok
 
-from ._default_config import default_config
+from ._default_config import default_config, _default_stylekit
 from ._page import _Page
 from .config import Config, ConfigParameter, _Config
 from .data.content_accessor import _ContentAccessor
@@ -1676,14 +1676,15 @@ class Gui:
                         for n, e in lib.get_elements().items()
                         if isinstance(e, Element) and not e._is_server_only()
                     ]
-        if self._get_config("stylekit", False):
-            config["stylekit"] = {_to_camel_case(k): v for k, v in self._get_config("stylekit_variables", {}).items()}
+        stylekit = self._get_config("stylekit", _default_stylekit)
+        if stylekit:
+            config["stylekit"] = {_to_camel_case(k): v for k, v in stylekit.items()}
         return config
 
     def __get_css_vars(self) -> str:
         css_vars = []
-        if self._get_config("stylekit", False):
-            stylekit = self._get_config("stylekit_variables", {})
+        stylekit = self._get_config("stylekit", _default_stylekit)
+        if stylekit:
             for k, v in stylekit.items():
                 css_vars.append(f'--{k.replace("_", "-")}:{_get_css_var_value(v)};')
         return " ".join(css_vars)
@@ -1774,7 +1775,7 @@ class Gui:
             for lib in libs
             for s in (lib.get_styles() or [])
         ]
-        if self._get_config("stylekit", False):
+        if self._get_config("stylekit", True):
             styles.append("/stylekit/stylekit.css")
         else:
             styles.append("https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap")


### PR DESCRIPTION
Addresses [taipy-doc/#398](https://github.com/Avaiga/taipy-doc/issues/398)

- Add a Styling section to all elements.
- Use a single 'stylekit'  parameter to Gui.run() to enable, disable and configure the Stylekit.
- Replace underscores in Stylekit classes by hyphens.
- Rename StylekitVariables to Stylekit.