### PR TITLE
Feature/taipy#126 group taipy cli args to subcommands

### DIFF
--- a/src/taipy/gui/__init__.py
+++ b/src/taipy/gui/__init__.py
@@ -91,6 +91,10 @@ from .renderers import Html, Markdown
 from .state import State
 from .utils import is_debugging
 
+from ._gui_cli import _GuiCLI
+
+_GuiCLI.create_parser()
+
 if find_spec("taipy") and find_spec("taipy.config"):
     from taipy.config import _inject_section
 
@@ -102,4 +106,5 @@ if find_spec("taipy") and find_spec("taipy.config"):
         "gui_config",
         _GuiSection(property_list=list(default_config)),
         [("configure_gui", _GuiSection._configure)],
+        add_to_unconflicted_sections=True,
     )

--- a/src/taipy/gui/__init__.py
+++ b/src/taipy/gui/__init__.py
@@ -91,10 +91,6 @@ from .renderers import Html, Markdown
 from .state import State
 from .utils import is_debugging
 
-from ._gui_cli import _GuiCLI
-
-_GuiCLI.create_parser()
-
 if find_spec("taipy") and find_spec("taipy.config"):
     from taipy.config import _inject_section
 

--- a/src/taipy/gui/_gui_cli.py
+++ b/src/taipy/gui/_gui_cli.py
@@ -9,15 +9,26 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.config.common._argparser import _Argparser
+from argparse import Namespace, ArgumentError
+from taipy.config._cli._argparser import _Argparser
 
 
 class _GuiCLI:
     """Command-line interface of GUI."""
+    _DEFAULT_ARGS = {
+        "port": "",
+        "host": "",
+        "ngrok_token": "",
+        "webapp_path": "",
+        "debug": False,
+        "no_debug": False,
+        "use_reloader": False,
+        "no_reloader": False,
+    }
 
     @classmethod
-    def _create_parser(cls):
-        gui_parser = _Argparser._add_groupparser("GUI", "Optional arguments for GUI service")
+    def create_parser(cls):
+        gui_parser = _Argparser._add_subparser("taipy", help="Run application with Taipy arguments.")
 
         gui_parser.add_argument("-P", "--port", nargs="?", default="", const="", help="Specify server port")
         gui_parser.add_argument("-H", "--host", nargs="?", default="", const="", help="Specify server host")
@@ -40,5 +51,21 @@ class _GuiCLI:
         reloader_group.add_argument("--no-reloader", help="No reload on code changes", action="store_true")
 
     @classmethod
-    def _parse_arguments(cls):
-        return _Argparser._parse()
+    def parse_arguments(cls):
+        try:
+            args = _Argparser._parse()
+        except ArgumentError:
+            return cls.default()
+
+        if getattr(args, "which", None) != "taipy":
+            return cls.default()
+
+        return args
+
+    @classmethod
+    def default(cls):
+        default_args = Namespace()
+        for attr, value in cls._DEFAULT_ARGS.items():
+            setattr(default_args, attr, value)
+
+        return default_args

--- a/src/taipy/gui/_gui_cli.py
+++ b/src/taipy/gui/_gui_cli.py
@@ -9,26 +9,15 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from argparse import Namespace, ArgumentError
-from taipy.config._cli._cli import _CLI
+from taipy.cli import _CLI
 
 
 class _GuiCLI:
     """Command-line interface of GUI."""
-    _DEFAULT_ARGS = {
-        "port": "",
-        "host": "",
-        "ngrok_token": "",
-        "webapp_path": "",
-        "debug": False,
-        "no_debug": False,
-        "use_reloader": False,
-        "no_reloader": False,
-    }
 
     @classmethod
     def create_parser(cls):
-        gui_parser = _CLI._add_subparser("taipy", help="Run application with Taipy arguments.")
+        gui_parser = _CLI._add_groupparser("Taipy GUI", "Optional arguments for Taipy GUI service")
 
         gui_parser.add_argument("-P", "--port", nargs="?", default="", const="", help="Specify server port")
         gui_parser.add_argument("-H", "--host", nargs="?", default="", const="", help="Specify server host")
@@ -52,20 +41,4 @@ class _GuiCLI:
 
     @classmethod
     def parse_arguments(cls):
-        try:
-            args = _CLI._parse()
-        except ArgumentError:
-            return cls.default()
-
-        if getattr(args, "which", None) != "taipy":
-            return cls.default()
-
-        return args
-
-    @classmethod
-    def default(cls):
-        default_args = Namespace()
-        for attr, value in cls._DEFAULT_ARGS.items():
-            setattr(default_args, attr, value)
-
-        return default_args
+        return _CLI._parse()

--- a/src/taipy/gui/_gui_cli.py
+++ b/src/taipy/gui/_gui_cli.py
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 from argparse import Namespace, ArgumentError
-from taipy.config._cli._argparser import _Argparser
+from taipy.config._cli._cli import _CLI
 
 
 class _GuiCLI:
@@ -28,7 +28,7 @@ class _GuiCLI:
 
     @classmethod
     def create_parser(cls):
-        gui_parser = _Argparser._add_subparser("taipy", help="Run application with Taipy arguments.")
+        gui_parser = _CLI._add_subparser("taipy", help="Run application with Taipy arguments.")
 
         gui_parser.add_argument("-P", "--port", nargs="?", default="", const="", help="Specify server port")
         gui_parser.add_argument("-H", "--host", nargs="?", default="", const="", help="Specify server host")
@@ -53,7 +53,7 @@ class _GuiCLI:
     @classmethod
     def parse_arguments(cls):
         try:
-            args = _Argparser._parse()
+            args = _CLI._parse()
         except ArgumentError:
             return cls.default()
 

--- a/src/taipy/gui/_gui_cli.py
+++ b/src/taipy/gui/_gui_cli.py
@@ -9,7 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from taipy.cli import _CLI
+from taipy._cli._base_cli import _CLI
 
 
 class _GuiCLI:

--- a/src/taipy/gui/config.py
+++ b/src/taipy/gui/config.py
@@ -184,6 +184,7 @@ class _Config(object):
         return tz
 
     def _handle_argparse(self):
+        _GuiCLI.create_parser()
         args = _GuiCLI.parse_arguments()
 
         config = self.config

--- a/src/taipy/gui/config.py
+++ b/src/taipy/gui/config.py
@@ -184,8 +184,7 @@ class _Config(object):
         return tz
 
     def _handle_argparse(self):
-        _GuiCLI._create_parser()
-        args = _GuiCLI._parse_arguments()
+        args = _GuiCLI.parse_arguments()
 
         config = self.config
         if args.port:

--- a/src/taipy/gui/config.py
+++ b/src/taipy/gui/config.py
@@ -243,9 +243,6 @@ class _Config(object):
                             f"Invalid env value in Gui.run(): {key} - {value}. Unable to parse value to the correct type:\n{e}"
                         )
 
-        # Load from system arguments
-        self._handle_argparse()
-
         # Taipy-config
         if find_spec("taipy") and find_spec("taipy.config"):
             from taipy.config import Config as TaipyConfig
@@ -255,6 +252,9 @@ class _Config(object):
                 self.config.update(section._to_dict())
             except KeyError:
                 _warn("taipy-config section for taipy-gui is not initialized.")
+
+        # Load from system arguments
+        self._handle_argparse()
 
     def __log_outside_reloader(self, logger, msg):
         if not is_running_from_reloader():

--- a/tests/taipy/gui/cli/__init__.py
+++ b/tests/taipy/gui/cli/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -51,8 +51,8 @@ def init_config():
     Config._serializer = _TomlSerializer()
     _Checker._checkers = [_GlobalConfigChecker]
 
-    from src.taipy.gui._default_config import default_config
-    from src.taipy.gui._gui_section import _GuiSection
+    from taipy.gui._default_config import default_config
+    from taipy.gui._gui_section import _GuiSection
     from taipy.config import _inject_section
 
     _inject_section(

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -1,0 +1,123 @@
+# Copyright 2023 Avaiga Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from src.taipy.gui import Gui
+from taipy.config import Config
+
+
+class NamedTemporaryFile:
+    def __init__(self, content=None):
+        with tempfile.NamedTemporaryFile("w", delete=False) as fd:
+            if content:
+                fd.write(content)
+            self.filename = fd.name
+
+    def read(self):
+        with open(self.filename, "r") as fp:
+            return fp.read()
+
+    def __del__(self):
+        os.unlink(self.filename)
+
+
+def test_gui_service_arguments_hierarchy():
+    # Test default configuration
+    gui = Gui()
+    gui.run(run_server=False)
+    service_config = gui._config.config
+    assert not service_config["allow_unsafe_werkzeug"]
+    assert service_config["async_mode"] == "gevent"
+    assert service_config["change_delay"] is None
+    assert service_config["chart_dark_template"] is None
+    assert service_config["dark_mode"]
+    assert service_config["dark_theme"] is None
+    assert not service_config["debug"]
+    assert not service_config["extended_status"]
+    assert service_config["favicon"] is None
+    assert not service_config["flask_log"]
+    assert service_config["host"] == "127.0.0.1"
+    assert service_config["light_theme"] is None
+    assert service_config["margin"] is None
+    assert service_config["ngrok_token"] == ""
+    assert service_config["notification_duration"] == 3000
+    assert service_config["propagate"]
+    assert service_config["run_browser"]
+    assert not service_config["run_in_thread"]
+    assert not service_config["run_server"]
+    assert not service_config["single_client"]
+    assert not service_config["system_notification"]
+    assert service_config["theme"] is None
+    assert service_config["time_zone"] is None
+    assert service_config["title"] is None
+    assert service_config["upload_folder"] is None
+    assert not service_config["use_arrow"]
+    assert not service_config["use_reloader"]
+    assert service_config["watermark"] == "Taipy inside"
+    assert service_config["webapp_path"] is None
+    assert service_config["port"] == 5000
+    gui.stop()
+
+    # Override default configuration by explicit defined arguments in Gui.run()
+    gui = Gui()
+    gui.run(run_server=False, watermark="", host="my_host", port=5001)
+    service_config = gui._config.config
+    assert service_config["watermark"] == ""
+    assert service_config["host"] == "my_host"
+    assert service_config["port"] == 5001
+    gui.stop()
+
+    # Override Gui.run() arguments by explicit defined arguments in Config.configure_gui()
+    Config.configure_gui(dark_mode=False, host="my_2nd_host", port=5002)
+    gui = Gui()
+    gui.run(run_server=False, watermark="", host="my_host", port=5001)
+    service_config = gui._config.config
+    assert not service_config["dark_mode"]
+    assert service_config["host"] == "my_2nd_host"
+    assert service_config["watermark"] == ""
+    assert service_config["port"] == 5002
+    gui.stop()
+
+    # Override Config.configure_gui() arguments by loading a TOML file with [gui] section
+    toml_config = NamedTemporaryFile(
+        content="""
+[TAIPY]
+
+[gui]
+host = "my_3rd_host"
+port = 5003
+use_reloader = "true:bool"
+    """
+    )
+    Config.load(toml_config.filename)
+    gui = Gui()
+    gui.run(run_server=False, host="my_host", port=5001)
+    service_config = gui._config.config
+    assert not service_config["dark_mode"]
+    assert service_config["host"] == "my_3rd_host"
+    assert service_config["port"] == 5003
+    assert service_config["use_reloader"]
+    gui.stop()
+
+    # Override TOML configuration file with CLI arguments
+    with patch("sys.argv", ["prog", "taipy", "--host", "my_4th_host", "--port", "5004", "--no-reloader", "--debug"]):
+        gui = Gui()
+        gui.run(run_server=False, host="my_host", port=5001)
+        service_config = gui._config.config
+        assert not service_config["dark_mode"]
+        assert service_config["host"] == "my_4th_host"
+        assert service_config["port"] == 5004
+        assert not service_config["use_reloader"]
+        assert service_config["debug"]
+        gui.stop()

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -39,7 +39,6 @@ class NamedTemporaryFile:
         os.unlink(self.filename)
 
 
-@pytest.fixture(scope="function", autouse=True)
 def init_config():
     Config.unblock_update()
     Config._default_config = _Config()._default_config()
@@ -62,6 +61,15 @@ def init_config():
         [("configure_gui", _GuiSection._configure)],
         add_to_unconflicted_sections=True,
     )
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_test(helpers):
+    init_config()
+    helpers.test_cleanup()
+    yield
+    init_config()
+    helpers.test_cleanup()
 
 
 def test_gui_service_arguments_hierarchy():

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -13,8 +13,15 @@ import os
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from src.taipy.gui import Gui
 from taipy.config import Config
+from taipy.config._config import _Config
+from taipy.config._serializer._toml_serializer import _TomlSerializer
+from taipy.config.checker._checker import _Checker
+from taipy.config.checker._checkers._gLobal_config_checker import _GlobalConfigChecker
+from taipy.config.checker.issue_collector import IssueCollector
 
 
 class NamedTemporaryFile:
@@ -30,6 +37,31 @@ class NamedTemporaryFile:
 
     def __del__(self):
         os.unlink(self.filename)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def init_config():
+    Config.unblock_update()
+    Config._default_config = _Config()._default_config()
+    Config._python_config = _Config()
+    Config._file_config = None
+    Config._env_file_config = None
+    Config._applied_config = _Config._default_config()
+    Config._collector = IssueCollector()
+    Config._serializer = _TomlSerializer()
+    _Checker._checkers = [_GlobalConfigChecker]
+
+    from src.taipy.gui._default_config import default_config
+    from src.taipy.gui._gui_section import _GuiSection
+    from taipy.config import _inject_section
+
+    _inject_section(
+        _GuiSection,
+        "gui_config",
+        _GuiSection(property_list=list(default_config)),
+        [("configure_gui", _GuiSection._configure)],
+        add_to_unconflicted_sections=True,
+    )
 
 
 def test_gui_service_arguments_hierarchy():

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -143,7 +143,7 @@ use_reloader = "true:bool"
     gui.stop()
 
     # Override TOML configuration file with CLI arguments
-    with patch("sys.argv", ["prog", "taipy", "--host", "my_4th_host", "--port", "5004", "--no-reloader", "--debug"]):
+    with patch("sys.argv", ["prog", "--host", "my_4th_host", "--port", "5004", "--no-reloader", "--debug"]):
         gui = Gui()
         gui.run(run_server=False, host="my_host", port=5001)
         service_config = gui._config.config

--- a/tests/taipy/gui/cli/test_cli.py
+++ b/tests/taipy/gui/cli/test_cli.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from src.taipy.gui import Gui
+from taipy.gui import Gui
 from taipy.config import Config
 from taipy.config._config import _Config
 from taipy.config._serializer._toml_serializer import _TomlSerializer


### PR DESCRIPTION
In this PR:
- Change the behavior (or a bug) where the arguments loaded from the toml file will override CLI arguments. It should be the other way around.
- Add loading args from TOML and CLI test case.