### PR TITLE
part height is dynamic (#785)

### DIFF
--- a/gui/src/components/Taipy/Part.tsx
+++ b/gui/src/components/Taipy/Part.tsx
@@ -27,7 +27,14 @@ interface PartProps extends TaipyBaseProps {
     children?: ReactNode;
     defaultPartial?: boolean;
     partial?: boolean;
+    height?: string;
+    defaultHeight?: string;
 }
+
+const IframeStyle = {
+    width: "100%",
+    height: "100%",
+};
 
 const Part = (props: PartProps) => {
     const { id, children, partial, defaultPartial } = props;
@@ -35,6 +42,7 @@ const Part = (props: PartProps) => {
 
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
     const render = useDynamicProperty(props.render, props.defaultRender, true);
+    const height = useDynamicProperty(props.height, props.defaultHeight, undefined);
     const page = useDynamicProperty(props.page, props.defaultPage, "");
     const iFrame = useMemo(() => {
         if (page && !defaultPartial) {
@@ -47,10 +55,11 @@ const Part = (props: PartProps) => {
         return false;
     }, [state.locations, page, defaultPartial]);
 
+    const boxSx = useMemo(() => (height ? { height: height } : undefined), [height]);
     return render ? (
-        <Box id={id} className={className}>
+        <Box id={id} className={className} sx={boxSx}>
             {iFrame ? (
-                <iframe src={page} />
+                <iframe src={page} style={IframeStyle} />
             ) : page ? (
                 <TaipyRendered path={"/" + page} partial={partial} fromBlock={true} />
             ) : null}

--- a/src/taipy/gui/renderers/factory.py
+++ b/src/taipy/gui/renderers/factory.py
@@ -355,7 +355,12 @@ class _Factory:
         )
         ._set_partial()  # partial should be set before page
         .set_attributes(
-            [("id",), ("page", PropertyType.dynamic_string), ("render", PropertyType.dynamic_boolean, True)]
+            [
+                ("id",),
+                ("page", PropertyType.dynamic_string),
+                ("render", PropertyType.dynamic_boolean, True),
+                ("height", PropertyType.dynamic_string),
+            ]
         ),
         "selector": lambda gui, control_type, attrs: _Builder(
             gui=gui, control_type=control_type, element_name="Selector", attributes=attrs, default_value=None

--- a/src/taipy/gui/version.json
+++ b/src/taipy/gui/version.json
@@ -1,1 +1,1 @@
-{"major": 2, "minor": 3, "patch": 0, "ext": "dev3"}
+{"major": 2, "minor": 3, "patch": 0, "ext": "dev4"}

--- a/src/taipy/gui/viselements.json
+++ b/src/taipy/gui/viselements.json
@@ -1118,6 +1118,11 @@
             "name": "page",
             "type": "dynamic(str)",
             "doc": "The page to show as the content of the block (page name if defined or an URL in an <i>iframe</i>).<br/>This should not be defined if <i>partial</i> is set."
+          },
+          {
+            "name": "height",
+            "type": "dynamic(str)",
+            "doc": "The height, in CSS units, of this block."
           }
         ]
       }


### PR DESCRIPTION
Addresses #784 and [doc#458](https://github.com/Avaiga/taipy-doc/issues/458).

iframe is 100% in size

```
from taipy.gui import Gui

height = "50vh"

page = """
#Part with iframe size

<|{height}|input|>

<|1 1|layout|

<|part|page=http://docs.taipy.io|>

<|part|page=http://taipy.io|height={height}|>
|>
"""

Gui(page).run()

```