### PR TITLE
fix typing of add_pages()

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # required by black, https://github.com/psf/black/blob/master/.flake8
 max-line-length = 120
 max-complexity = 18
-ignore = E203, E266, E501, E722, W503, F403, F401
+ignore = E203, E266, E501, E722, W503, F403, F401, F811
 select = B,C,E,F,W,T4,B9
 docstring-convention = google
 per-file-ignores =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     - id: black
       args: [--line-length=120]
       language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -1340,7 +1340,7 @@ class Gui:
         # Update variable directory
         self.__var_dir.add_frame(page._frame)
 
-    def add_pages(self, pages: t.Optional[t.Union[t.Dict[str, t.Union[str, Page]], str]] = None) -> None:
+    def add_pages(self, pages: t.Optional[t.Union[t.Mapping[str, t.Union[str, Page]], str]] = None) -> None:
         """Add several pages to the Graphical User Interface.
 
         Arguments:

--- a/src/taipy/gui/types.py
+++ b/src/taipy/gui/types.py
@@ -128,10 +128,36 @@ class PropertyType(Enum):
     inner = "inner"
 
 
-def _get_taipy_type(a_type: t.Optional[PropertyType]) -> t.Optional[t.Type[_TaipyBase]]:
+@t.overload
+def _get_taipy_type(a_type: None) -> None:
+    ...
+
+
+@t.overload
+def _get_taipy_type(a_type: t.Type[_TaipyBase]) -> t.Type[_TaipyBase]:
+    ...
+
+
+@t.overload
+def _get_taipy_type(a_type: PropertyType) -> t.Type[_TaipyBase]:
+    ...
+
+
+@t.overload
+def _get_taipy_type(
+    a_type: t.Optional[t.Union[t.Type[_TaipyBase], t.Type[Decimator], PropertyType]]
+) -> t.Optional[t.Union[t.Type[_TaipyBase], t.Type[Decimator], PropertyType]]:
+    ...
+
+
+def _get_taipy_type(
+    a_type: t.Optional[t.Union[t.Type[_TaipyBase], t.Type[Decimator], PropertyType]]
+) -> t.Optional[t.Union[t.Type[_TaipyBase], t.Type[Decimator], PropertyType]]:
+    if a_type is None:
+        return None
     if isinstance(a_type, PropertyType) and not isinstance(a_type.value, str):
         return a_type.value
-    if isclass(a_type) and issubclass(a_type, _TaipyBase):
+    if isclass(a_type) and not isinstance(a_type, PropertyType) and issubclass(a_type, _TaipyBase):
         return a_type
     if a_type == PropertyType.boolean:
         return _TaipyBool


### PR DESCRIPTION
If you do
```python
pages = {"/" : "### Page1", "/foo" : "### Page 2"}
Gui=gui()
gui.add_pages(pages)
```
then pyright (in VS Code) complains that `pages` is incorrect type. 

That's because you have the type as `dict[Union[str, Page]]` but `dict` is invariant, while `Mapping` is covariant.

So this fixes that issue.

For the pre-commit to work, I also had to fix something in `types.py` because `mypy` was complaining.

Also fixed the pre-commit that grabs flake8 from gitlab, but it is on github.  And since I added overloads, had to add an error code to the `.flake8` configuration.
