### PR TITLE
Missing return type warning in doc generation

### DIFF
--- a/src/taipy/gui/_gui_section.py
+++ b/src/taipy/gui/_gui_section.py
@@ -46,7 +46,7 @@ class _GuiSection(UniqueSection):
         self._properties.update(as_dict)
 
     @staticmethod
-    def _configure(**properties):
+    def _configure(**properties) -> "_GuiSection":
         """NOT DOCUMENTED
         Configure the Graphical User Interface.
 


### PR DESCRIPTION
Addresses [doc/#490](https://github.com/Avaiga/taipy-doc/issues/490)