### PR TITLE
Use date picker when editing date column (#797 #867)

### DIFF
--- a/gui/src/components/Taipy/AutoLoadingTable.tsx
+++ b/gui/src/components/Taipy/AutoLoadingTable.tsx
@@ -400,7 +400,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
     const isItemLoaded = useCallback((index: number) => index < rows.length && !!rows[index], [rows]);
 
     const onCellValidation: OnCellValidation = useCallback(
-        (value: RowValue, rowIndex: number, colName: string, userValue: string) =>
+        (value: RowValue, rowIndex: number, colName: string, userValue: string, tz?: string) =>
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onEdit,
@@ -408,6 +408,7 @@ const AutoLoadingTable = (props: TaipyTableProps) => {
                     index: getRowIndex(rows[rowIndex], rowIndex),
                     col: colName,
                     user_value: userValue,
+                    tz: tz,
                 })
             ),
         [dispatch, updateVarName, onEdit, rows, module]

--- a/gui/src/components/Taipy/DateSelector.tsx
+++ b/gui/src/components/Taipy/DateSelector.tsx
@@ -22,7 +22,7 @@ import { ErrorBoundary } from "react-error-boundary";
 
 import { createSendUpdateAction } from "../../context/taipyReducers";
 import { getSuffixedClassNames, TaipyActiveProps, TaipyChangeProps } from "./utils";
-import { getDateTime, getClientServerTimeZoneOffset } from "../../utils";
+import { getDateTime, getTimeZonedDate } from "../../utils";
 import { useClassNames, useDispatch, useDynamicProperty, useFormatConfig, useModule } from "../../utils/hooks";
 import Field from "./Field";
 import ErrorFallback from "../../utils/ErrorBoundary";
@@ -56,21 +56,7 @@ const DateSelector = (props: DateSelectorProps) => {
         (v: Date | null) => {
             setValue(v);
             if (v !== null && isValid(v)) {
-                const newDate = v;
-                // dispatch new date which offset by the timeZone differences between client and server
-                const hours = getClientServerTimeZoneOffset(tz) / 60;
-                const minutes = getClientServerTimeZoneOffset(tz) % 60;
-                newDate.setSeconds(0);
-                newDate.setMilliseconds(0);
-                if (withTime) {
-                    // Parse data with selected time if it is a datetime selector
-                    newDate.setHours(newDate.getHours() + hours);
-                    newDate.setMinutes(newDate.getMinutes() + minutes);
-                } else {
-                    // Parse data with 00:00 UTC time if it is a date selector
-                    newDate.setHours(hours);
-                    newDate.setMinutes(minutes);
-                }
+                const newDate = getTimeZonedDate(v, tz, withTime);
                 dispatch(createSendUpdateAction(updateVarName, newDate.toISOString(), module, props.onChange, propagate));
             }
         },

--- a/gui/src/components/Taipy/PaginatedTable.tsx
+++ b/gui/src/components/Taipy/PaginatedTable.tsx
@@ -348,7 +348,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
     }, [value]);
 
     const onCellValidation: OnCellValidation = useCallback(
-        (value: RowValue, rowIndex: number, colName: string, userValue: string) =>
+        (value: RowValue, rowIndex: number, colName: string, userValue: string, tz?: string) =>
             dispatch(
                 createSendActionNameAction(updateVarName, module, {
                     action: onEdit,
@@ -356,6 +356,7 @@ const PaginatedTable = (props: TaipyPaginatedTableProps) => {
                     index: getRowIndex(rows[rowIndex], rowIndex, startIndex),
                     col: colName,
                     user_value: userValue,
+                    tz: tz,
                 })
             ),
         [dispatch, updateVarName, onEdit, rows, startIndex, module]

--- a/gui/src/utils/index.ts
+++ b/gui/src/utils/index.ts
@@ -58,6 +58,26 @@ interface StyleKit {
     inputButtonHeight: string;
 }
 
+// return date with right time and tz
+export const getTimeZonedDate = (d: Date, tz: string, withTime: boolean) => {
+    const newDate = d;
+    // dispatch new date which offset by the timeZone differences between client and server
+    const hours = getClientServerTimeZoneOffset(tz) / 60;
+    const minutes = getClientServerTimeZoneOffset(tz) % 60;
+    newDate.setSeconds(0);
+    newDate.setMilliseconds(0);
+    if (withTime) {
+        // Parse data with selected time if it is a datetime selector
+        newDate.setHours(newDate.getHours() + hours);
+        newDate.setMinutes(newDate.getMinutes() + minutes);
+    } else {
+        // Parse data with 00:00 UTC time if it is a date selector
+        newDate.setHours(hours);
+        newDate.setMinutes(minutes);
+    }
+    return newDate;
+};
+
 // return client server timeZone offset in minutes
 export const getClientServerTimeZoneOffset = (tz: string): number =>
     (getTimezoneOffset(TIMEZONE_CLIENT) - getTimezoneOffset(tz)) / 60000;
@@ -67,7 +87,7 @@ export const getDateTime = (value: string | null | undefined, tz?: string): Date
         return null;
     }
     try {
-        return (tz && tz !== "Etc/Unknown") ? utcToZonedTime(value, tz) : new Date(value);
+        return tz && tz !== "Etc/Unknown" ? utcToZonedTime(value, tz) : new Date(value);
     } catch (e) {
         return null;
     }
@@ -79,7 +99,11 @@ export const getDateTimeString = (
     formatConf: FormatConfig,
     tz?: string
 ): string =>
-    formatInTimeZone(getDateTime(value) || "", formatConf.forceTZ || !tz ? formatConf.timeZone : tz, datetimeformat || formatConf.dateTime);
+    formatInTimeZone(
+        getDateTime(value) || "",
+        formatConf.forceTZ || !tz ? formatConf.timeZone : tz,
+        datetimeformat || formatConf.dateTime
+    );
 
 export const getNumberString = (value: number, numberformat: string | undefined, formatConf: FormatConfig): string => {
     try {
@@ -112,7 +136,7 @@ export const getTypeFromDf = (dataType?: string) => {
             return "boolean";
     }
     return dataType;
-}
+};
 
 export const formatWSValue = (
     value: string | number,


### PR DESCRIPTION
Addresses #797 and #867.

on_edit callback should handle the date column depending on the type of datetime used in the dataframe
```
dr = pd.date_range(start="3/1/2023", periods=10, freq="D")
df = pd.DataFrame(
    {"dates": list(dr)}
)

def myedit(state: State, var_name: str, action: str, payload: dict):
    val = parser.parse(payload["value"]).astimezone(ZoneInfo(payload["tz"])).replace(tzinfo=None) if payload["col"] == "dates" else payload["value"]
    state.df.at[payload["index"], payload["col"]] = val
    state.refresh("df")

page = "<|{df}|table|id=df|on_edit=myedit|width=250px|date_format=dd/MM/yy|>"

```