### PR TITLE
Extension: allow property replacement

### DIFF
--- a/src/taipy/gui/extension/library.py
+++ b/src/taipy/gui/extension/library.py
@@ -159,9 +159,9 @@ class Element:
                 if val:
                     # handling property replacement in inner properties <tp:prop:...>
                     while m := Element.__RE_PROP_VAR.search(val):
-                        if (var:= attributes.get(m.group(1))):
-                            hash_value = gui._evaluate_expr(var)
-                            val = val[:m.start()] + hash_value + val[m.end():]
+                        var = attributes.get(m.group(1))
+                        hash_value = "None" if var is None else gui._evaluate_expr(var)
+                        val = val[:m.start()] + hash_value + val[m.end():]
                 attributes[prop] = val
         # this modifies attributes
         hash_names = _Builder._get_variable_hash_names(gui, attributes)  # variable replacement

--- a/src/taipy/gui/extension/library.py
+++ b/src/taipy/gui/extension/library.py
@@ -87,6 +87,7 @@ class Element:
     An element is defined by its properties (name, type and default value) and
     what the default property name is.
     """
+
     __RE_PROP_VAR = re.compile(r"<tp:prop:(\w+)>")
 
     def __init__(
@@ -161,7 +162,7 @@ class Element:
                     while m := Element.__RE_PROP_VAR.search(val):
                         var = attributes.get(m.group(1))
                         hash_value = "None" if var is None else gui._evaluate_expr(var)
-                        val = val[:m.start()] + hash_value + val[m.end():]
+                        val = val[: m.start()] + hash_value + val[m.end() :]
                 attributes[prop] = val
         # this modifies attributes
         hash_names = _Builder._get_variable_hash_names(gui, attributes)  # variable replacement

--- a/tests/taipy/gui/extension/test_library.py
+++ b/tests/taipy/gui/extension/test_library.py
@@ -51,6 +51,18 @@ class MyLibrary(ElementLibrary):
             "h1",
             render_xhtml=render_xhtml_4_my_library_fail,
         ),
+        "inner": Element(
+            "value",
+            {
+                "value": ElementProperty(PropertyType.string, "")
+            },
+            inner_properties = {
+                "with_property": ElementProperty(
+                    PropertyType.react,
+                    f"{{<tp:prop:value>}}",
+                ),
+            }
+        )
     }
 
     def get_name(self) -> str:
@@ -123,3 +135,17 @@ def test_lib_input_html_2(gui: Gui, test_client, helpers):
         "value={tpec_TpExPr_val_TPMDL_0}",
     ]
     helpers.test_control_html(gui, html_string, expected_list)
+
+
+def test_lib_inner_md(gui: Gui, test_client, helpers):
+    val = "title"  # noqa: F841
+    gui._set_frame(inspect.currentframe())
+    md_string = "<|{val}|test_lib.inner|>"
+    expected = ["<TestLib_Inner", "value={tpec_TpExPr_val_TPMDL_0}", "withProperty={tpec_TpExPr_tpec_TpExPr_val_TPMDL_0_TPMDL_0}"]
+    helpers.test_control_md(gui, md_string, expected)
+
+def test_lib_inner_no_value_md(gui: Gui, test_client, helpers):
+    gui._set_frame(inspect.currentframe())
+    md_string = "<|test_lib.inner|>"
+    expected = ["<TestLib_Inner", "withProperty={tpec_TpExPr_None_TPMDL_0}"]
+    helpers.test_control_md(gui, md_string, expected)

--- a/tests/taipy/gui/extension/test_library.py
+++ b/tests/taipy/gui/extension/test_library.py
@@ -53,16 +53,14 @@ class MyLibrary(ElementLibrary):
         ),
         "inner": Element(
             "value",
-            {
-                "value": ElementProperty(PropertyType.string, "")
-            },
-            inner_properties = {
+            {"value": ElementProperty(PropertyType.string, "")},
+            inner_properties={
                 "with_property": ElementProperty(
                     PropertyType.react,
                     f"{{<tp:prop:value>}}",
                 ),
-            }
-        )
+            },
+        ),
     }
 
     def get_name(self) -> str:
@@ -141,8 +139,13 @@ def test_lib_inner_md(gui: Gui, test_client, helpers):
     val = "title"  # noqa: F841
     gui._set_frame(inspect.currentframe())
     md_string = "<|{val}|test_lib.inner|>"
-    expected = ["<TestLib_Inner", "value={tpec_TpExPr_val_TPMDL_0}", "withProperty={tpec_TpExPr_tpec_TpExPr_val_TPMDL_0_TPMDL_0}"]
+    expected = [
+        "<TestLib_Inner",
+        "value={tpec_TpExPr_val_TPMDL_0}",
+        "withProperty={tpec_TpExPr_tpec_TpExPr_val_TPMDL_0_TPMDL_0}",
+    ]
     helpers.test_control_md(gui, md_string, expected)
+
 
 def test_lib_inner_no_value_md(gui: Gui, test_client, helpers):
     gui._set_frame(inspect.currentframe())


### PR DESCRIPTION
allows to define a property as part of an expression
ie <tp:prop:...property name...> will be replaced by the property value or expression or None if it is not defined