### PR TITLE
Add the range selection capability to the slider element

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,12 +6,12 @@ name = "pypi"
 [packages]
 "backports.zoneinfo" = {version="==0.2.1", markers="python_version < '3.9'", extras=["tzdata"]}
 flask = "==2.2.5"
-flask-cors = "==3.0.10"
-flask-socketio = "==5.3.0"
-gevent = "==22.10.2"
+flask-cors = "==4.0.0"
+flask-socketio = "==5.3.6"
+gevent = "==23.7.0"
 gevent-websocket = "==0.10.1"
 kthread = "==0.2.3"
-markdown = "==3.4.1"
+markdown = "==3.4.4"
 pandas = "==2.0.0"
 pyarrow = "==10.0.1"
 pyngrok = "==5.1"
@@ -19,11 +19,11 @@ python-dotenv = "==0.19"
 python-magic = {version = "==0.4.24", markers="sys_platform != 'win32'"}
 python-magic-bin = {version = "==0.4.14", markers="sys_platform == 'win32'"}
 pytz = "==2021.3"
-simple-websocket = "==0.9"
+simple-websocket = "==0.10.1"
 taipy-config = {ref = "develop", git = "https://github.com/avaiga/taipy-config.git"}
 tzlocal = "==3.0"
 gitignore-parser = "==0.1.1"
-twisted = "==22.10.0"
+twisted = "==23.8.0"
 
 [dev-packages]
 black = "*"

--- a/gui/dom/package-lock.json
+++ b/gui/dom/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taipy-gui-dom",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taipy-gui-dom",
-      "version": "2.3.0",
+      "version": "3.0.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -15,7 +15,7 @@
     },
     "../packaging": {
       "name": "taipy-gui",
-      "version": "2.3.0"
+      "version": "3.0.0"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/gui/packaging/taipy-gui.d.ts
+++ b/gui/packaging/taipy-gui.d.ts
@@ -105,7 +105,7 @@ export interface TaipyTableProps extends TaipyActiveProps, TaipyMultiSelectProps
     nanValue?: string;
     filter?: boolean;
     size?: "small" | "medium";
-    userData?: string;
+    userData?: unknown;
 }
 export interface TaipyPaginatedTableProps extends TaipyTableProps {
     pageSizeOptions?: string;

--- a/gui/src/components/Taipy/Slider.spec.tsx
+++ b/gui/src/components/Taipy/Slider.spec.tsx
@@ -82,6 +82,13 @@ describe("Slider Component", () => {
             type: "SEND_UPDATE_ACTION",
         });
     });
+    it("holds a numeric range", async () => {
+        const { getByDisplayValue } = render(<Slider defaultValue={[10,90]} value={undefined as unknown as number[]} />);
+        const elt1 = getByDisplayValue("10");
+        expect(elt1.tagName).toBe("INPUT");
+        const elt2 = getByDisplayValue("90");
+        expect(elt2.tagName).toBe("INPUT");
+    });
     it("shows discrete value when lov", async () => {
         const { getAllByText } = render(
             <Slider
@@ -106,6 +113,13 @@ describe("Slider Component", () => {
         const elts = getAllByText("Item 1");
         expect(elts).toHaveLength(1);
         expect(elts[0].tagName).toBe("P");
+    });
+    it("holds a lov range", async () => {
+        const { getByDisplayValue } = render(<Slider value={["B", "C"]} defaultLov={'[["A", "A"], ["B", "B"], ["C", "C"], ["D", "D"]]'} />);
+        const elt1 = getByDisplayValue("1");
+        expect(elt1.tagName).toBe("INPUT");
+        const elt2 = getByDisplayValue("2");
+        expect(elt2.tagName).toBe("INPUT");
     });
     it("shows marks", async () => {
         const { getAllByText } = render(

--- a/gui/src/components/Taipy/Slider.spec.tsx
+++ b/gui/src/components/Taipy/Slider.spec.tsx
@@ -83,7 +83,7 @@ describe("Slider Component", () => {
         });
     });
     it("holds a numeric range", async () => {
-        const { getByDisplayValue } = render(<Slider defaultValue={[10,90]} value={undefined as unknown as number[]} />);
+        const { getByDisplayValue } = render(<Slider defaultValue={"[10,90]"} value={undefined as unknown as number[]} />);
         const elt1 = getByDisplayValue("10");
         expect(elt1.tagName).toBe("INPUT");
         const elt2 = getByDisplayValue("90");

--- a/gui/src/components/Taipy/tableUtils.tsx
+++ b/gui/src/components/Taipy/tableUtils.tsx
@@ -112,7 +112,7 @@ export interface TaipyTableProps extends TaipyActiveProps, TaipyMultiSelectProps
     filter?: boolean;
     size?: "small" | "medium";
     defaultKey?: string; // for testing purposes only
-    userData?: string;
+    userData?: unknown;
 }
 
 export type PageSizeOptionsType = (

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,6 @@ filterwarnings =
     ignore::DeprecationWarning:twisted
     ignore::DeprecationWarning:pandas
     ignore::DeprecationWarning:numpy
+    ignore::FutureWarning:pyarrow
 markers =
     teste2e:End-to-end tests

--- a/setup.py
+++ b/setup.py
@@ -30,21 +30,21 @@ with open(f"src{os.sep}taipy{os.sep}gui{os.sep}version.json") as version_file:
 
 requirements = [
     "flask>=2.2,<2.3",
-    "flask-cors>=3.0.10,<4.0",
-    "flask-socketio>=5.3.0,<6.0",
-    "markdown>=3.4.1,<4.0",
+    "flask-cors>=4.0.0,<5.0",
+    "flask-socketio>=5.3.6,<6.0",
+    "markdown>=3.4.4,<4.0",
     "pandas>=2.0.0,<3.0",
     "python-dotenv>=0.19,<0.21",
     "pytz>=2021.3,<2022.2",
     "tzlocal>=3.0,<5.0",
     "backports.zoneinfo>=0.2.1,<0.3;python_version<'3.9'",
-    "gevent>=22.10.2,<23.0",
+    "gevent>=23.7.0,<24.0",
     "gevent-websocket>=0.10.1,<0.11",
     "kthread>=0.2.3,<0.3",
     "taipy-config@git+https://git@github.com/Avaiga/taipy-config.git@develop",
     "gitignore-parser>=0.1,<0.2",
-    "simple-websocket>=0.9,<1.0",
-    "twisted>=22.10",
+    "simple-websocket>=0.10.1,<1.0",
+    "twisted>=23.8.0,<24.0",
 ]
 
 test_requirements = ["pytest>=3.8"]

--- a/src/taipy/gui/renderers/builder.py
+++ b/src/taipy/gui/renderers/builder.py
@@ -9,7 +9,6 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-import collections.abc
 import contextlib
 import json
 import numbers
@@ -723,9 +722,11 @@ class _Builder:
                 var_type = PropertyType.lov_value
                 native_type = False
             else:
-                var_type = (PropertyType.dynamic_lo_numbers
-                            if isinstance(self._Builder__attributes.get("value"), collections.abc.Sequence)
-                            else PropertyType.dynamic_number)
+                var_type = (
+                    PropertyType.dynamic_lo_numbers
+                    if isinstance(self.__attributes.get("value"), list)
+                    else PropertyType.dynamic_number
+                )
                 native_type = True
         if var_type == PropertyType.dynamic_boolean:
             return self.set_attributes([(var_name, var_type, bool(default_val), with_update)])

--- a/src/taipy/gui/renderers/builder.py
+++ b/src/taipy/gui/renderers/builder.py
@@ -9,6 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import collections.abc
 import contextlib
 import json
 import numbers
@@ -717,9 +718,15 @@ class _Builder:
             default_val (optional(Any)): the default value.
         """
         var_name = self.__default_property_name if var_name is None else var_name
-        if var_type == PropertyType.number_or_lov_value:
-            var_type = PropertyType.lov_value if self.__attributes.get("lov") else PropertyType.dynamic_number
-            native_type = native_type if var_type == PropertyType.dynamic_number else False
+        if var_type == PropertyType.slider_value:
+            if self.__attributes.get("lov"):
+                var_type = PropertyType.lov_value
+                native_type = False
+            else:
+                var_type = (PropertyType.dynamic_lo_numbers
+                            if isinstance(self._Builder__attributes.get("value"), collections.abc.Sequence)
+                            else PropertyType.dynamic_number)
+                native_type = True
         if var_type == PropertyType.dynamic_boolean:
             return self.set_attributes([(var_name, var_type, bool(default_val), with_update)])
         if hash_name := self.__hashes.get(var_name):

--- a/src/taipy/gui/renderers/factory.py
+++ b/src/taipy/gui/renderers/factory.py
@@ -391,7 +391,7 @@ class _Factory:
             attributes=attrs,
             default_value=0,
         )
-        .set_value_and_default(native_type=True, var_type=PropertyType.number_or_lov_value)
+        .set_value_and_default(native_type=True, var_type=PropertyType.slider_value)
         .set_attributes(
             [
                 ("active", PropertyType.dynamic_boolean, True),

--- a/src/taipy/gui/types.py
+++ b/src/taipy/gui/types.py
@@ -22,10 +22,10 @@ from .utils import (
     _TaipyData,
     _TaipyDate,
     _TaipyDict,
+    _TaipyLoNumbers,
     _TaipyLov,
     _TaipyLovValue,
     _TaipyNumber,
-    _TaipyLoNumbers,
 )
 
 

--- a/src/taipy/gui/types.py
+++ b/src/taipy/gui/types.py
@@ -25,6 +25,7 @@ from .utils import (
     _TaipyLov,
     _TaipyLovValue,
     _TaipyNumber,
+    _TaipyLoNumbers,
 )
 
 
@@ -79,6 +80,10 @@ class PropertyType(Enum):
     """
     The property holds a dynamic number.
     """
+    dynamic_lo_numbers = _TaipyLoNumbers
+    """
+    The property holds a dynamic list of numbers.
+    """
     dynamic_boolean = _TaipyBool
     """
     The property holds a dynamic Boolean value.
@@ -119,7 +124,7 @@ class PropertyType(Enum):
     This is typically used to handle CSS dimension values, where a unit can be used.
     """
     boolean_or_list = "boolean|list"
-    number_or_lov_value = "number|lovValue"
+    slider_value = "number|number[]|lovValue"
     string_list = "stringlist"
     decimator = Decimator
     """

--- a/src/taipy/gui/utils/__init__.py
+++ b/src/taipy/gui/utils/__init__.py
@@ -44,9 +44,9 @@ from .types import (
     _TaipyData,
     _TaipyDate,
     _TaipyDict,
+    _TaipyLoNumbers,
     _TaipyLov,
     _TaipyLovValue,
     _TaipyNumber,
-    _TaipyLoNumbers,
 )
 from .varnamefromcontent import _varname_from_content

--- a/src/taipy/gui/utils/__init__.py
+++ b/src/taipy/gui/utils/__init__.py
@@ -47,5 +47,6 @@ from .types import (
     _TaipyLov,
     _TaipyLovValue,
     _TaipyNumber,
+    _TaipyLoNumbers,
 )
 from .varnamefromcontent import _varname_from_content

--- a/src/taipy/gui/utils/types.py
+++ b/src/taipy/gui/utils/types.py
@@ -97,6 +97,21 @@ class _TaipyNumber(_TaipyBase):
         return _TaipyBase._HOLDER_PREFIX + "N"
 
 
+class _TaipyLoNumbers(_TaipyBase):
+    def cast_value(self, value: t.Any):
+        if isinstance(value, str):
+            try:
+                return list(map(lambda f: float(f), value[1:-1].split(",")))
+            except Exception as e:
+                _warn(f"{self._get_readable_name()}: Parsing {value} as an array of numbers:\n{e}")
+                return []
+        return super().cast_value(value)
+
+    @staticmethod
+    def get_hash():
+        return _TaipyBase._HOLDER_PREFIX + "Ln"
+
+
 class _TaipyDate(_TaipyBase):
     def get(self):
         val = super().get()

--- a/src/taipy/gui/viselements.json
+++ b/src/taipy/gui/viselements.json
@@ -130,8 +130,8 @@
           {
             "name": "value",
             "default_property": true,
-            "type": "dynamic(int|float|str)",
-            "doc": "The value that is set for this slider.<br/>It would be a <i>lov</i> label if it is used."
+            "type": "dynamic(int|float|str|float[])",
+            "doc": "The value that is set for this slider.<br/>It would be a <i>lov</i> label if it is used.<br/>This value can also hold an array of numbers to indicate that the slider reflects a range (within the [<i>min</i>,<i>max</i>] domain) defined by several knobs that the user can move around."
           },
           {
             "name": "min",

--- a/src/taipy/gui/viselements.json
+++ b/src/taipy/gui/viselements.json
@@ -130,8 +130,8 @@
           {
             "name": "value",
             "default_property": true,
-            "type": "dynamic(int|float|str|float[])",
-            "doc": "The value that is set for this slider.<br/>It would be a <i>lov</i> label if it is used.<br/>This value can also hold an array of numbers to indicate that the slider reflects a range (within the [<i>min</i>,<i>max</i>] domain) defined by several knobs that the user can move around."
+            "type": "dynamic(int|float|int[]|float[]|str|str[])",
+            "doc": "The value that is set for this slider.<br/>If this slider is based on a <i>lov</i> then this property can be set to the lov element.<br/>This value can also hold an array of numbers to indicate that the slider reflects a range (within the [<i>min</i>,<i>max</i>] domain) defined by several knobs that the user can set independently.<br/>If this slider is based on a <i>lov</i> then this property can be set to an array of lov elements. The slider is then represented with several knobs, one for each lov value."
           },
           {
             "name": "min",

--- a/tests/taipy/gui/control/test_slider.py
+++ b/tests/taipy/gui/control/test_slider.py
@@ -92,7 +92,7 @@ def test_slider_text_anchor_default_md(gui: Gui, test_client, helpers):
 
 
 def test_slider_array_md(gui: Gui, test_client, helpers):
-    gui._bind_var_val("x", [10,20])
+    gui._bind_var_val("x", [10, 20])
     md_string = "<|{x}|slider|>"
     expected_list = [
         "<Slider",

--- a/tests/taipy/gui/control/test_slider.py
+++ b/tests/taipy/gui/control/test_slider.py
@@ -91,6 +91,17 @@ def test_slider_text_anchor_default_md(gui: Gui, test_client, helpers):
     helpers.test_control_md(gui, md_string, expected_list)
 
 
+def test_slider_array_md(gui: Gui, test_client, helpers):
+    gui._bind_var_val("x", [10,20])
+    md_string = "<|{x}|slider|>"
+    expected_list = [
+        "<Slider",
+        'updateVarName="_TpLn_tpec_TpExPr_x_TPMDL_0"',
+        "value={_TpLn_tpec_TpExPr_x_TPMDL_0}",
+    ]
+    helpers.test_control_md(gui, md_string, expected_list)
+
+
 def test_slider_html_1(gui: Gui, test_client, helpers):
     gui._bind_var_val("x", 10)
     html_string = '<taipy:slider value="{x}" />'

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ commands =
 platform = linux
 commands =
     pipenv install --dev
-    pipenv run pip install jsonschema==4.17.3
     pipenv run ipython kernel install --name "python3" --user
     pipenv run playwright install chromium --with-deps
     pipenv run mypy --config-file mypy.ini src
@@ -38,7 +37,6 @@ commands =
 platform = win32
 commands =
     pipenv install --dev
-    pipenv run pip install jsonschema==4.17.3
     pipenv run ipython kernel install --name "python3" --user
     pipenv run playwright install chromium --with-deps
     pipenv run pytest -s tests
@@ -47,7 +45,6 @@ commands =
 platform = darwin
 commands =
     pipenv install --dev
-    pipenv run pip install jsonschema==4.17.3
     pipenv run ipython kernel install --name "python3" --user
     pipenv run playwright install chromium --with-deps
     pipenv run pytest -s tests


### PR DESCRIPTION
Addresses #875.

- Range of Lovs not taken into account (yet?)

All these should work:
```
from taipy.gui import Gui

num_value = 25
array_value = [20, 60]
stalov_value = "Item 3"
dynlov = [
    ("First", "first value"),
    ("Second", "second value"),
    ("Third", "third value"),
]
dynlov_value = "First"
arrlov=["XXS","XS","S","M","L","XL","XXL"]
arrlov_value=["XS","XL"]

page="""# Slider

## Simple slider (<|{num_value}|>)
<|{num_value}|slider|id=num|>

## Array slider (<|{array_value}|>)
<|{array_value}|slider|id=array|>

## Static lov (<|{stalov_value}|>)
<|{stalov_value}|slider|lov=Item 1;Item 2;Item 3|text_anchor=top|labels=Min:Min;Item 2:Another|labels|id=stlov|>

## Complex lov (<|{dynlov_value}|>)
<|{dynlov_value}|slider|lov={dynlov}|labels|id=dynlov|>

## Array lov (<|{arrlov_value}|>)
<|{arrlov_value}|slider|lov={arrlov}|id=lovarr|>
""" 

def on_change(s, vn, vv):
    print(f"On_CHANGE. {vn}={vv}")

Gui(page=page).run(run_browser=False)
```