### PR TITLE
Fix timezone (#895, #923)

### DIFF
--- a/gui/src/components/Taipy/DateSelector.spec.tsx
+++ b/gui/src/components/Taipy/DateSelector.spec.tsx
@@ -143,7 +143,7 @@ describe("DateSelector Component", () => {
             await userEvent.type(input, "{ArrowLeft}{ArrowLeft}{ArrowLeft}01012001", { delay: 1 });
             expect(dispatch).toHaveBeenLastCalledWith({
                 name: "",
-                payload: { value: "2001-01-01T00:00:00.000Z" },
+                payload: { value: "Mon Jan 01 2001" },
                 propagate: true,
                 type: "SEND_UPDATE_ACTION",
             });

--- a/gui/src/components/Taipy/DateSelector.tsx
+++ b/gui/src/components/Taipy/DateSelector.tsx
@@ -22,7 +22,7 @@ import { ErrorBoundary } from "react-error-boundary";
 
 import { createSendUpdateAction } from "../../context/taipyReducers";
 import { getSuffixedClassNames, TaipyActiveProps, TaipyChangeProps } from "./utils";
-import { getDateTime, getTimeZonedDate } from "../../utils";
+import { dateToString, getDateTime, getTimeZonedDate } from "../../utils";
 import { useClassNames, useDispatch, useDynamicProperty, useFormatConfig, useModule } from "../../utils/hooks";
 import Field from "./Field";
 import ErrorFallback from "../../utils/ErrorBoundary";
@@ -37,14 +37,14 @@ interface DateSelectorProps extends TaipyActiveProps, TaipyChangeProps {
 }
 
 const boxSx = { display: "inline-block" };
-const textFieldProps = {textField: {margin:"dense"}} as BaseDateTimePickerSlotsComponentsProps<Date>;
+const textFieldProps = { textField: { margin: "dense" } } as BaseDateTimePickerSlotsComponentsProps<Date>;
 
 const DateSelector = (props: DateSelectorProps) => {
     const { updateVarName, withTime = false, id, propagate = true } = props;
     const dispatch = useDispatch();
     const formatConfig = useFormatConfig();
     const tz = formatConfig.timeZone;
-    const [value, setValue] = useState(() => getDateTime(props.defaultDate, tz));
+    const [value, setValue] = useState(() => getDateTime(props.defaultDate, tz, withTime));
     const module = useModule();
 
     const className = useClassNames(props.libClassName, props.dynamicClassName, props.className);
@@ -57,7 +57,15 @@ const DateSelector = (props: DateSelectorProps) => {
             setValue(v);
             if (v !== null && isValid(v)) {
                 const newDate = getTimeZonedDate(v, tz, withTime);
-                dispatch(createSendUpdateAction(updateVarName, newDate.toISOString(), module, props.onChange, propagate));
+                dispatch(
+                    createSendUpdateAction(
+                        updateVarName,
+                        dateToString(newDate, withTime),
+                        module,
+                        props.onChange,
+                        propagate
+                    )
+                );
             }
         },
         [updateVarName, dispatch, withTime, propagate, tz, props.onChange, module]
@@ -66,9 +74,9 @@ const DateSelector = (props: DateSelectorProps) => {
     // Run every time props.value get updated
     useEffect(() => {
         if (props.date !== undefined) {
-            setValue(getDateTime(props.date, tz));
+            setValue(getDateTime(props.date, tz, withTime));
         }
-    }, [props.date, tz]);
+    }, [props.date, tz, withTime]);
 
     return (
         <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/gui/src/components/Taipy/tableUtils.tsx
+++ b/gui/src/components/Taipy/tableUtils.tsx
@@ -27,7 +27,7 @@ import { BaseDateTimePickerSlotsComponentsProps } from "@mui/x-date-pickers/Date
 import { isValid } from "date-fns";
 
 import { FormatConfig } from "../../context/taipyReducers";
-import { getDateTime, getDateTimeString, getNumberString, getTimeZonedDate } from "../../utils/index";
+import { dateToString, getDateTime, getDateTimeString, getNumberString, getTimeZonedDate } from "../../utils/index";
 import { TaipyActiveProps, TaipyMultiSelectProps } from "./utils";
 
 /**
@@ -291,7 +291,7 @@ export const EditableCell = (props: EditableCellProps) => {
                 if (val === null) {
                     castedVal = val;
                 } else if (isValid(val)) {
-                    castedVal = getTimeZonedDate(val as Date, formatConfig.timeZone, withTime).toISOString();
+                    castedVal = dateToString(getTimeZonedDate(val as Date, formatConfig.timeZone, withTime), withTime);
                 } else {
                     return;
                 }
@@ -312,11 +312,11 @@ export const EditableCell = (props: EditableCellProps) => {
         (evt?: MouseEvent) => {
             evt && evt.stopPropagation();
             colDesc.type?.startsWith("date")
-                ? setVal(getDateTime(value as string, formatConfig.timeZone))
+                ? setVal(getDateTime(value as string, formatConfig.timeZone, withTime))
                 : setVal(value);
             onValidation && setEdit((e) => !e);
         },
-        [onValidation, value, formatConfig.timeZone, colDesc.type]
+        [onValidation, value, formatConfig.timeZone, colDesc.type, withTime]
     );
 
     const onKeyDown = useCallback(

--- a/gui/src/context/taipyReducers.ts
+++ b/gui/src/context/taipyReducers.ts
@@ -57,6 +57,7 @@ export interface TaipyState {
     theme: Theme;
     locations: Record<string, string>;
     timeZone?: string;
+    dateFormat?: string;
     dateTimeFormat?: string;
     numberFormat?: string;
     alerts: AlertMessage[];
@@ -151,6 +152,7 @@ interface TaipyPartialAction extends TaipyBaseAction {
 export interface FormatConfig {
     timeZone: string;
     forceTZ: boolean;
+    date: string;
     dateTime: string;
     number: string;
 }

--- a/gui/src/utils/hooks.ts
+++ b/gui/src/utils/hooks.ts
@@ -105,7 +105,7 @@ export const useFormatConfig = (): FormatConfig => {
                 timeZone: state.timeZone || TIMEZONE_CLIENT,
                 forceTZ: !!state.timeZone,
                 dateTime: state.dateTimeFormat || "yyyy-MM-dd HH:mm:ss zzz",
-                date: state.dateFormat || "yyyy/MM/dd",
+                date: state.dateFormat || "yyyy-MM-dd",
                 number: state.numberFormat || "%f",
             } as FormatConfig),
         [state.timeZone, state.dateFormat, state.dateTimeFormat, state.numberFormat]

--- a/gui/src/utils/hooks.ts
+++ b/gui/src/utils/hooks.ts
@@ -105,9 +105,10 @@ export const useFormatConfig = (): FormatConfig => {
                 timeZone: state.timeZone || TIMEZONE_CLIENT,
                 forceTZ: !!state.timeZone,
                 dateTime: state.dateTimeFormat || "yyyy-MM-dd HH:mm:ss zzz",
+                date: state.dateFormat || "yyyy/MM/dd",
                 number: state.numberFormat || "%f",
             } as FormatConfig),
-        [state.timeZone, state.dateTimeFormat, state.numberFormat]
+        [state.timeZone, state.dateFormat, state.dateTimeFormat, state.numberFormat]
     );
 };
 

--- a/gui/src/utils/index.spec.ts
+++ b/gui/src/utils/index.spec.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
     console.warn = myWarn;
 })
 
-const getFormatConfig = (numberFormat?: string): FormatConfig => ({timeZone: "", dateTime: "", number: numberFormat || "", forceTZ: false})
+const getFormatConfig = (numberFormat?: string): FormatConfig => ({timeZone: "", date: "", dateTime: "", number: numberFormat || "", forceTZ: false})
 
 describe("getNumberString", () => {
     it("returns straight", async () => {

--- a/src/taipy/gui/renderers/builder.py
+++ b/src/taipy/gui/renderers/builder.py
@@ -22,7 +22,7 @@ from .._warnings import _warn
 from ..partial import Partial
 from ..types import PropertyType, _get_taipy_type
 from ..utils import (
-    _date_to_ISO,
+    _date_to_string,
     _get_broadcast_var_name,
     _get_client_var_name,
     _get_data_type,
@@ -676,7 +676,7 @@ class _Builder:
             value = self.__attributes.get(var_name)
         default_var_name = _to_camel_case(f"default_{var_name}")
         if isinstance(value, (datetime, date, time)):
-            return self.set_attribute(default_var_name, _date_to_ISO(value))
+            return self.set_attribute(default_var_name, _date_to_string(value))
         elif isinstance(value, str):
             return self.set_attribute(default_var_name, value)
         elif native_type and isinstance(value, numbers.Number):

--- a/src/taipy/gui/renderers/json.py
+++ b/src/taipy/gui/renderers/json.py
@@ -18,7 +18,7 @@ from flask.json.provider import DefaultJSONProvider
 
 from .._warnings import _warn
 from ..icon import Icon
-from ..utils import _date_to_ISO, _MapDict, _TaipyBase
+from ..utils import _date_to_string, _MapDict, _TaipyBase
 
 
 def _default(o):
@@ -29,7 +29,7 @@ def _default(o):
     if isinstance(o, _TaipyBase):
         return o.get()
     if isinstance(o, (datetime, date, time)):
-        return _date_to_ISO(o)
+        return _date_to_string(o)
     if isinstance(o, Path):
         return str(o)
     try:

--- a/src/taipy/gui/utils/__init__.py
+++ b/src/taipy/gui/utils/__init__.py
@@ -24,7 +24,7 @@ from ._variable_directory import _variable_decode, _variable_encode, _VariableDi
 from .boolean import _is_boolean, _is_boolean_true
 from .clientvarname import _get_broadcast_var_name, _get_client_var_name, _to_camel_case
 from .datatype import _get_data_type
-from .date import _date_to_ISO, _ISO_to_date
+from .date import _date_to_string, _string_to_date
 from .expr_var_name import _get_expr_var_name
 from .filename import _get_non_existent_file_path
 from .filter_locals import _filter_locals

--- a/src/taipy/gui/utils/date.py
+++ b/src/taipy/gui/utils/date.py
@@ -19,7 +19,7 @@ from pytz import utc
 from .._warnings import _warn
 
 
-def _date_to_ISO(date_val: t.Union[datetime, date, time]) -> str:
+def _date_to_string(date_val: t.Union[datetime, date, time]) -> str:
     if isinstance(date_val, datetime):
         # return date.isoformat() + 'Z', if possible
         try:
@@ -31,7 +31,7 @@ def _date_to_ISO(date_val: t.Union[datetime, date, time]) -> str:
     return date_val.isoformat()
 
 
-def _ISO_to_date(date_str: str) -> t.Union[datetime, date]:
+def _string_to_date(date_str: str) -> t.Union[datetime, date]:
     # return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S.%fZ')
     # return datetime.fromisoformat(date_str)
     date = parser.parse(date_str)

--- a/src/taipy/gui/utils/date.py
+++ b/src/taipy/gui/utils/date.py
@@ -9,6 +9,7 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+import re
 import typing as t
 from datetime import date, datetime, time
 
@@ -30,7 +31,9 @@ def _date_to_ISO(date_val: t.Union[datetime, date, time]) -> str:
     return date_val.isoformat()
 
 
-def _ISO_to_date(date_str: str) -> datetime:
+def _ISO_to_date(date_str: str) -> t.Union[datetime, date]:
     # return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S.%fZ')
     # return datetime.fromisoformat(date_str)
-    return parser.parse(date_str)
+    date = parser.parse(date_str)
+    date_regex = r"^[A-Z][a-z]{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{2} \d{4}$"
+    return date.date() if re.match(date_regex, date_str) else date

--- a/src/taipy/gui/utils/types.py
+++ b/src/taipy/gui/utils/types.py
@@ -15,7 +15,7 @@ from abc import ABC
 from datetime import datetime
 
 from .._warnings import _warn
-from . import _date_to_ISO, _ISO_to_date, _MapDict, _variable_decode
+from . import _date_to_string, _MapDict, _string_to_date, _variable_decode
 
 
 class _TaipyBase(ABC):
@@ -116,14 +116,14 @@ class _TaipyDate(_TaipyBase):
     def get(self):
         val = super().get()
         if isinstance(val, datetime):
-            val = _date_to_ISO(val)
+            val = _date_to_string(val)
         elif val is not None:
             val = str(val)
         return val
 
     def cast_value(self, value: t.Any):
         if isinstance(value, str):
-            return _ISO_to_date(value)
+            return _string_to_date(value)
         return super().cast_value(value)
 
     @staticmethod

--- a/tests/taipy/gui/e2e/test_timezone.py
+++ b/tests/taipy/gui/e2e/test_timezone.py
@@ -65,3 +65,18 @@ def _timezone_test_template(page: "Page", gui: Gui, helpers, time_zone, texts):
     page.wait_for_selector("#text1")
     text1 = page.query_selector("#text1")
     assert text1.inner_text() in texts
+
+
+def test_date_only(page: "Page", gui: Gui, helpers):
+    page_md = """
+<|{t}|id=text1|>
+"""
+    t = _ISO_to_date("Wed Jul 28 1993")  # noqa: F841
+    gui._set_frame(inspect.currentframe())
+    gui.add_page(name="test", page=page_md)
+    helpers.run_e2e(gui)
+    page.goto("./test")
+    page.expect_websocket()
+    page.wait_for_selector("#text1")
+    text1 = page.query_selector("#text1")
+    assert text1.inner_text() in ["1993/07/28"]

--- a/tests/taipy/gui/e2e/test_timezone.py
+++ b/tests/taipy/gui/e2e/test_timezone.py
@@ -18,7 +18,7 @@ if util.find_spec("playwright"):
     from playwright._impl._page import Page
 
 from taipy.gui import Gui
-from taipy.gui.utils.date import _ISO_to_date
+from taipy.gui.utils.date import _string_to_date
 
 
 @pytest.mark.teste2e
@@ -56,7 +56,7 @@ def _timezone_test_template(page: "Page", gui: Gui, helpers, time_zone, texts):
     page_md = """
 <|{t}|id=text1|>
 """
-    t = _ISO_to_date("2022-03-03T00:00:00.000Z")  # noqa: F841
+    t = _string_to_date("2022-03-03T00:00:00.000Z")  # noqa: F841
     gui._set_frame(inspect.currentframe())
     gui.add_page(name="test", page=page_md)
     helpers.run_e2e(gui, time_zone=time_zone)
@@ -71,7 +71,7 @@ def test_date_only(page: "Page", gui: Gui, helpers):
     page_md = """
 <|{t}|id=text1|>
 """
-    t = _ISO_to_date("Wed Jul 28 1993")  # noqa: F841
+    t = _string_to_date("Wed Jul 28 1993")  # noqa: F841
     gui._set_frame(inspect.currentframe())
     gui.add_page(name="test", page=page_md)
     helpers.run_e2e(gui)
@@ -79,4 +79,4 @@ def test_date_only(page: "Page", gui: Gui, helpers):
     page.expect_websocket()
     page.wait_for_selector("#text1")
     text1 = page.query_selector("#text1")
-    assert text1.inner_text() in ["1993/07/28"]
+    assert text1.inner_text() in ["1993-07-28"]

--- a/tests/taipy/gui/utils/test_types.py
+++ b/tests/taipy/gui/utils/test_types.py
@@ -14,7 +14,7 @@ import warnings
 
 import pytest
 
-from taipy.gui.utils.date import _ISO_to_date
+from taipy.gui.utils.date import _string_to_date
 from taipy.gui.utils.types import _TaipyBase, _TaipyBool, _TaipyDate, _TaipyNumber
 
 
@@ -47,8 +47,8 @@ def test_taipy_number():
 
 
 def test_taipy_date():
-    assert _TaipyDate(_ISO_to_date("2022-03-03 00:00:00 UTC"), "x").get() == "2022-03-03T00:00:00+00:00"
+    assert _TaipyDate(_string_to_date("2022-03-03 00:00:00 UTC"), "x").get() == "2022-03-03T00:00:00+00:00"
     assert _TaipyDate("2022-03-03 00:00:00 UTC", "x").get() == "2022-03-03 00:00:00 UTC"
     assert _TaipyDate(None, "x").get() is None
     _TaipyDate("", "x").cast_value("2022-03-03 00:00:00 UTC")
-    _TaipyDate("", "x").cast_value(_ISO_to_date("2022-03-03 00:00:00 UTC"))
+    _TaipyDate("", "x").cast_value(_string_to_date("2022-03-03 00:00:00 UTC"))


### PR DESCRIPTION
Solve bug #895, #923

A few test run is included

no time date selector

```python
import datetime as dt
from src.taipy.gui import Gui
from dateutil import parser

selected_date = dt.date.today()

md = """
# Timezone issue

<|{selected_date}|date|not with_time|>

<|{selected_date}|>

<|{repr(selected_date)}|>
"""


if __name__ == "__main__":
    gui = Gui(md)
    gui.run(time_zone="Etc/UTC")
```

table with no time
```python
import pandas as pd
from datetime import datetime
import src.taipy.gui.builder as tgb
from src.taipy.gui import Gui

start_date = datetime(2023, 1, 1)
end_date = datetime(2023, 2, 1)
date_range = pd.date_range(start=start_date, end=end_date)

df = pd.DataFrame({'Date': date_range})
df["Index"] = df.index

print(df)

def on_edit(state, var_name, action, payload):
    print(var_name, action, payload)

# with tgb.Page() as page:
#     tgb.table(data="{df}", editable=True, filter=True, on_edit=on_edit)

page = """
<|{df}|table|on_edit=on_edit|editable=True|filter=True|>
"""

Gui(page=page).run()
```

table with time
```python
import pandas as pd
from datetime import datetime
import src.taipy.gui.builder as tgb
from src.taipy.gui import Gui

start_datetime = datetime(2023, 1, 1, 0, 0, 0)
end_datetime = datetime(2023, 1, 3, 23, 59, 59)
datetime_range = pd.date_range(start=start_datetime, end=end_datetime, freq='H')

df = pd.DataFrame({'Date': datetime_range})
df["Index"] = df.index

print(df)

def on_edit(state, var_name, action, payload):
    print(var_name, action, payload)

# with tgb.Page() as page:
#     tgb.table(data="{df}", editable=True, filter=True, on_edit=on_edit)

page = """
<|{df}|table|on_edit=on_edit|editable=True|filter=True|date_format=yyyy-MM-dd HH:mm:ss zzz|>
"""

Gui(page=page).run()
```