### PR TITLE
handle libraries (other than taipy) in HTML renderer

### DIFF
--- a/src/taipy/gui/_renderers/_html/factory.py
+++ b/src/taipy/gui/_renderers/_html/factory.py
@@ -19,5 +19,5 @@ class _HtmlFactory(_Factory):
     def create_element(gui, namespace: str, control_type: str, all_properties: t.Dict[str, str]) -> t.Tuple[str, str]:
         builder_html = _Factory.call_builder(gui, f"{namespace}.{control_type}", all_properties, True)
         if builder_html is None:
-            return f"<div>INVALID SYNTAX - Control is '{namespace}:{control_type}'", "div"
+            return f"<div>INVALID SYNTAX - Control is '{namespace}:{control_type}'</div>", "div"
         return builder_html  # type: ignore

--- a/src/taipy/gui/_renderers/_html/parser.py
+++ b/src/taipy/gui/_renderers/_html/parser.py
@@ -93,7 +93,7 @@ class _TaipyHTMLParser(HTMLParser):
     def parse_taipy_tag(self) -> None:
         tp_string, tp_element_name = self.taipy_tag.parse(self._gui)
         self.append_data(tp_string)
-        self.tag_mapping[f"taipy:{self.taipy_tag.control_type}"] = tp_element_name
+        self.tag_mapping[f"{self.taipy_tag.namespace}:{self.taipy_tag.control_type}"] = tp_element_name
         self.taipy_tag = None
 
     def get_jsx(self) -> str:

--- a/tests/taipy/gui/extension/test_library.py
+++ b/tests/taipy/gui/extension/test_library.py
@@ -135,6 +135,7 @@ def test_lib_input_html_1(gui: Gui, test_client, helpers):
         'defaultValue=""',
         "broadcast={_bc_broadcast}",
         "value={tpec_TpExPr_val_TPMDL_0}",
+        "</TestLib_Input>"
     ]
     helpers.test_control_html(gui, html_string, expected_list)
 
@@ -142,13 +143,14 @@ def test_lib_input_html_1(gui: Gui, test_client, helpers):
 def test_lib_input_html_2(gui: Gui, test_client, helpers):
     val = ""  # noqa: F841
     gui._set_frame(inspect.currentframe())
-    html_string = '<test_lib:testinput multiline="true">{val}</testlib:testinput>'
+    html_string = '<test_lib:testinput multiline="true">{val}</test_lib:testinput>'
     expected_list = [
         "<TestLib_Input",
         "multiline={true}",
         'defaultValue=""',
         "broadcast={_bc_broadcast}",
         "value={tpec_TpExPr_val_TPMDL_0}",
+        "</TestLib_Input>"
     ]
     helpers.test_control_html(gui, html_string, expected_list)
 

--- a/tests/taipy/gui/extension/test_library.py
+++ b/tests/taipy/gui/extension/test_library.py
@@ -135,7 +135,7 @@ def test_lib_input_html_1(gui: Gui, test_client, helpers):
         'defaultValue=""',
         "broadcast={_bc_broadcast}",
         "value={tpec_TpExPr_val_TPMDL_0}",
-        "</TestLib_Input>"
+        "</TestLib_Input>",
     ]
     helpers.test_control_html(gui, html_string, expected_list)
 
@@ -150,7 +150,7 @@ def test_lib_input_html_2(gui: Gui, test_client, helpers):
         'defaultValue=""',
         "broadcast={_bc_broadcast}",
         "value={tpec_TpExPr_val_TPMDL_0}",
-        "</TestLib_Input>"
+        "</TestLib_Input>",
     ]
     helpers.test_control_html(gui, html_string, expected_list)
 


### PR DESCRIPTION
support for

```
<h1>Scenario html</h1>
<taipy_gui_core:scenario_selector>{scenario}</taipy_gui_core:scenario_selector>
<taipy_gui_core:scenario>{scenario}</taipy_gui_core:scenario>
<taipy_gui_core:scenario_dag width="100%">{scenario}</taipy_gui_core:scenario_dag>
```