### PR TITLE
support custom user content function

### DIFF
--- a/src/taipy/gui/_renderers/builder.py
+++ b/src/taipy/gui/_renderers/builder.py
@@ -15,8 +15,8 @@ import numbers
 import typing as t
 import xml.etree.ElementTree as etree
 from datetime import date, datetime, time
-import time as _time
 from inspect import isclass
+import time as _time
 from urllib.parse import quote
 
 from .._warnings import _warn

--- a/src/taipy/gui/_renderers/builder.py
+++ b/src/taipy/gui/_renderers/builder.py
@@ -15,6 +15,7 @@ import numbers
 import typing as t
 import xml.etree.ElementTree as etree
 from datetime import date, datetime, time
+import time as _time
 from inspect import isclass
 from urllib.parse import quote
 
@@ -848,6 +849,25 @@ class _Builder:
             self.__set_react_attribute(_to_camel_case(name), _get_client_var_name(hash_name))
         return self
 
+    def __set_html_content(self, name: str, property_name: str, property_type: PropertyType):
+        hash_name = self.__hashes.get(name)
+        if not hash_name:
+            return self
+        front_var = self.__get_typed_hash_name(hash_name, property_type)
+        self.set_attribute(
+            _to_camel_case(f"default_{property_name}"),
+            self.__gui._get_user_content_url(
+                None,
+                {
+                    "variable_name": front_var,
+                    self.__gui._HTML_CONTENT_KEY: str(_time.time()),
+                },
+            ),
+        )
+        return self.__set_react_attribute(
+            _to_camel_case(property_name), _get_client_var_name(front_var)
+        )
+
     def set_attributes(self, attributes: t.List[tuple]):  # noqa: C901
         """
         TODO-undocumented
@@ -922,6 +942,8 @@ class _Builder:
                 self.__set_dynamic_property_without_default(
                     attr[0], var_type, _get_tuple_val(attr, 2, None) == "optional"
                 )
+            elif var_type == PropertyType.toHtmlContent:
+                self.__set_html_content(attr[0], "page", var_type)
             elif isclass(var_type) and issubclass(var_type, _TaipyBase):
                 if hash_name := self.__hashes.get(attr[0]):
                     prop_name = _to_camel_case(attr[0])

--- a/src/taipy/gui/_renderers/builder.py
+++ b/src/taipy/gui/_renderers/builder.py
@@ -12,11 +12,11 @@
 import contextlib
 import json
 import numbers
+import time as _time
 import typing as t
 import xml.etree.ElementTree as etree
 from datetime import date, datetime, time
 from inspect import isclass
-import time as _time
 from urllib.parse import quote
 
 from .._warnings import _warn
@@ -864,9 +864,7 @@ class _Builder:
                 },
             ),
         )
-        return self.__set_react_attribute(
-            _to_camel_case(property_name), _get_client_var_name(front_var)
-        )
+        return self.__set_react_attribute(_to_camel_case(property_name), _get_client_var_name(front_var))
 
     def set_attributes(self, attributes: t.List[tuple]):  # noqa: C901
         """

--- a/src/taipy/gui/_renderers/factory.py
+++ b/src/taipy/gui/_renderers/factory.py
@@ -384,6 +384,7 @@ class _Factory:
                 ("page", PropertyType.dynamic_string),
                 ("render", PropertyType.dynamic_boolean, True),
                 ("height", PropertyType.dynamic_string),
+                ("content", PropertyType.toHtmlContent),
             ]
         ),
         "selector": lambda gui, control_type, attrs: _Builder(

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -404,7 +404,7 @@ class Gui:
             _warn(f"The type {content_type} is already associated with a provider.")
             return
         if not callable(content_provider):
-            _warn(f"the provider for {content_type} should be a function.")
+            _warn(f"The provider for {content_type} must be a function.")
             return
         Gui.__content_providers[content_type] = content_provider
 

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -770,7 +770,7 @@ class Gui:
                     args.append(qargs)
                 ret = self._call_function_with_state(cb_function, args)
                 if ret is None:
-                    _warn(f"{cb_function_name}() callback function should return a value.")
+                    _warn(f"{cb_function_name}() callback function must return a value.")
                 else:
                     return (ret, 200)
             except Exception as e:  # pragma: no cover

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -423,7 +423,7 @@ class Gui:
                     _warn(f"Error in content provider for type {str(type(content))}", e)
         return (
             '<div style="background:white;color:red;">'
-            + (f"No valid provider for type {type(content).__name__}" if content else "wrong context.")
+            + (f"No valid provider for type {type(content).__name__}" if content else "Wrong context.")
             + "</div>"
         )
 

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -78,6 +78,7 @@ from .utils import (
     _setscopeattr_drill,
     _TaipyBase,
     _TaipyContent,
+    _TaipyContentHtml,
     _TaipyContentImage,
     _TaipyData,
     _TaipyLov,
@@ -206,6 +207,8 @@ class Gui:
     __BRDCST_CALLBACK_G_ID = "taipy_brdcst_callback"
     __SELF_VAR = "__gui"
     __DO_NOT_UPDATE_VALUE = _DoNotUpdate()
+    _HTML_CONTENT_KEY = "__taipy_html_content"
+    __USER_CONTENT_CB = "custom_user_content_cb"
 
     __RE_HTML = re.compile(r"(.*?)\.html$")
     __RE_MD = re.compile(r"(.*?)\.md$")
@@ -226,6 +229,8 @@ class Gui:
     __extensions: t.Dict[str, t.List[ElementLibrary]] = {}
 
     __shared_variables: t.List[str] = []
+
+    __content_providers: t.Dict[type, t.Callable[..., str]] = {}
 
     def __init__(
         self,
@@ -383,6 +388,40 @@ class Gui:
             raise RuntimeError(
                 f"add_library() argument should be a subclass of ElementLibrary instead of '{type(library)}'"
             )
+
+    @staticmethod
+    def register_content_provider(content_type: type, content_provider: t.Callable[..., str]) -> None:
+        """Add a custom content provider.
+
+        This application will be able to use custom content in the part content property.
+
+        Arguments:
+            content_type: The type of the content that will trigger the use of the provider.
+            content_provider: The function that will convert every content of the specified type into an html string.
+
+        """
+        if Gui.__content_providers.get(content_type):
+            _warn(f"the type {content_type} is already associated with a provider.")
+            return
+        if not callable(content_provider):
+            _warn(f"the provider for {content_type} should be a function.")
+            return
+        Gui.__content_providers[content_type] = content_provider
+
+    def __process_content_provider(self, state: State, path: str, query: t.Dict[str, str]):
+        variable_name = query.get("variable_name")
+        content = None
+        if variable_name:
+            content = _getscopeattr(self, variable_name)
+            if isinstance(content, _TaipyContentHtml):
+                content = content.get()
+            provider_fn = Gui.__content_providers.get(type(content))
+            if callable(provider_fn):
+                try:
+                    return provider_fn(content)
+                except Exception as e:
+                    _warn(f"Error in content provider for type {str(type(content))}", e)
+        return '<div style="background:white;color:red;">' + (f"No valid provider for type {type(content).__name__}" if content else "wrong context.") + '</div>'
 
     @staticmethod
     def add_shared_variable(*names: str) -> None:
@@ -683,30 +722,35 @@ class Gui:
     ) -> t.Optional[str]:
         qargs = query_args or {}
         qargs.update({Gui.__ARG_CLIENT_ID: self._get_client_id()})
-        return f"/{Gui.__USER_CONTENT_URL}/{path or ''}?{urlencode(qargs)}"
+        return f"/{Gui.__USER_CONTENT_URL}/{path or 'TaIpY'}?{urlencode(qargs)}"
 
     def __serve_user_content(self, path: str) -> t.Any:
         self.__set_client_id_in_context()
         qargs: t.Dict[str, str] = {}
         qargs.update(request.args)
         qargs.pop(Gui.__ARG_CLIENT_ID, None)
-        cb_function_name = qargs.get("custom_user_content_cb")
-        cb_function = None
-        if cb_function_name:
-            cb_function = self._get_user_function(cb_function_name)
-            if not callable(cb_function):
-                parts = cb_function_name.split(".", 1)
-                if len(parts) > 1:
-                    base = _getscopeattr(self, parts[0], None)
-                    if base and (meth := getattr(base, parts[1], None)):
-                        cb_function = meth
-                    else:
-                        base = self.__evaluator._get_instance_in_context(parts[0])
+        cb_function: t.Optional[t.Union[t.Callable, str]] = None
+        cb_function_name = None
+        if qargs.get(Gui._HTML_CONTENT_KEY):
+            cb_function = self.__process_content_provider
+            cb_function_name = cb_function.__name__
+        else:
+            cb_function_name = qargs.get(Gui.__USER_CONTENT_CB)
+            if cb_function_name:
+                cb_function = self._get_user_function(cb_function_name)
+                if not callable(cb_function):
+                    parts = cb_function_name.split(".", 1)
+                    if len(parts) > 1:
+                        base = _getscopeattr(self, parts[0], None)
                         if base and (meth := getattr(base, parts[1], None)):
                             cb_function = meth
-            if not callable(cb_function):
-                _warn(f"{cb_function_name}() callback function has not been defined.")
-                cb_function = None
+                        else:
+                            base = self.__evaluator._get_instance_in_context(parts[0])
+                            if base and (meth := getattr(base, parts[1], None)):
+                                cb_function = meth
+                if not callable(cb_function):
+                    _warn(f"{cb_function_name}() callback function has not been defined.")
+                    cb_function = None
         if cb_function is None:
             cb_function_name = "on_user_content"
             if hasattr(self, cb_function_name) and callable(self.on_user_content):
@@ -842,7 +886,7 @@ class Gui:
 
     _data_request_counter = 1
 
-    def __send_var_list_update(
+    def __send_var_list_update(  # noqa C901
         self,
         modified_vars: t.List[str],
         front_var: t.Optional[str] = None,
@@ -850,7 +894,7 @@ class Gui:
         ws_dict = {}
         values = {v: _getscopeattr_drill(self, v) for v in modified_vars}
         for k, v in values.items():
-            if isinstance(v, _TaipyData) and v.get_name() in modified_vars:
+            if isinstance(v, (_TaipyData, _TaipyContentHtml)) and v.get_name() in modified_vars:
                 modified_vars.remove(v.get_name())
             elif isinstance(v, _DoNotUpdate):
                 modified_vars.remove(k)
@@ -869,6 +913,10 @@ class Gui:
                         newvalue = f"/{Gui.__CONTENT_ROOT}/{ret_value[0]}"
                     else:
                         newvalue = ret_value
+                elif isinstance(newvalue, _TaipyContentHtml):
+                    newvalue = self._get_user_content_url(
+                        None, {"variable_name": str(_var), Gui._HTML_CONTENT_KEY: str(time.time())}
+                    )
                 elif isinstance(newvalue, _TaipyLov):
                     newvalue = [self.__adapter._run_for_var(newvalue.get_name(), elt) for elt in newvalue.get()]
                 elif isinstance(newvalue, _TaipyLovValue):

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -401,7 +401,7 @@ class Gui:
 
         """
         if Gui.__content_providers.get(content_type):
-            _warn(f"the type {content_type} is already associated with a provider.")
+            _warn(f"The type {content_type} is already associated with a provider.")
             return
         if not callable(content_provider):
             _warn(f"the provider for {content_type} should be a function.")

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -421,7 +421,11 @@ class Gui:
                     return provider_fn(content)
                 except Exception as e:
                     _warn(f"Error in content provider for type {str(type(content))}", e)
-        return '<div style="background:white;color:red;">' + (f"No valid provider for type {type(content).__name__}" if content else "wrong context.") + '</div>'
+        return (
+            '<div style="background:white;color:red;">'
+            + (f"No valid provider for type {type(content).__name__}" if content else "wrong context.")
+            + "</div>"
+        )
 
     @staticmethod
     def add_shared_variable(*names: str) -> None:

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -695,7 +695,7 @@ class Gui:
         if cb_function_name:
             cb_function = self._get_user_function(cb_function_name)
             if not callable(cb_function):
-                parts = cb_function_name.split(".", 2)
+                parts = cb_function_name.split(".", 1)
                 if len(parts) > 1:
                     base = _getscopeattr(self, parts[0], None)
                     if base and (meth := getattr(base, parts[1], None)):

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -393,11 +393,11 @@ class Gui:
     def register_content_provider(content_type: type, content_provider: t.Callable[..., str]) -> None:
         """Add a custom content provider.
 
-        The application can use custom content for the `part` block when its \*content\* property is set to an object with type \*type\*.
+        The application can use custom content for the `part` block when its *content* property is set to an object with type *type*.
 
         Arguments:
             content_type: The type of the content that triggers the content provider.
-            content_provider: The function that converts content of type \*type\* into an HTML string.
+            content_provider: The function that converts content of type *type* into an HTML string.
 
         """
         if Gui.__content_providers.get(content_type):

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -397,7 +397,7 @@ class Gui:
 
         Arguments:
             content_type: The type of the content that triggers the content provider.
-            content_provider: The function that will convert every content of the specified type into an html string.
+            content_provider: The function that converts content of type \*type\* into an HTML string.
 
         """
         if Gui.__content_providers.get(content_type):

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -396,7 +396,7 @@ class Gui:
         The application can use custom content for the `part` block when its \*content\* property is set to an object with type \*type\*.
 
         Arguments:
-            content_type: The type of the content that will trigger the use of the provider.
+            content_type: The type of the content that triggers the content provider.
             content_provider: The function that will convert every content of the specified type into an html string.
 
         """

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -393,7 +393,7 @@ class Gui:
     def register_content_provider(content_type: type, content_provider: t.Callable[..., str]) -> None:
         """Add a custom content provider.
 
-        This application will be able to use custom content in the part content property.
+        The application can use custom content for the `part` block when its \*content\* property is set to an object with type \*type\*.
 
         Arguments:
             content_type: The type of the content that will trigger the use of the provider.

--- a/src/taipy/gui/types.py
+++ b/src/taipy/gui/types.py
@@ -18,6 +18,7 @@ from .utils import (
     _TaipyBase,
     _TaipyBool,
     _TaipyContent,
+    _TaipyContentHtml,
     _TaipyContentImage,
     _TaipyData,
     _TaipyDate,
@@ -66,6 +67,7 @@ class PropertyType(Enum):
     """
     The property holds a Boolean value.
     """
+    toHtmlContent = _TaipyContentHtml
     content = _TaipyContent
     data = _TaipyData
     date = _TaipyDate

--- a/src/taipy/gui/utils/__init__.py
+++ b/src/taipy/gui/utils/__init__.py
@@ -40,6 +40,7 @@ from .types import (
     _TaipyBase,
     _TaipyBool,
     _TaipyContent,
+    _TaipyContentHtml,
     _TaipyContentImage,
     _TaipyData,
     _TaipyDate,

--- a/src/taipy/gui/utils/_evaluator.py
+++ b/src/taipy/gui/utils/_evaluator.py
@@ -329,3 +329,6 @@ class _Evaluator:
                     modified_vars.add(holder_hash)
             modified_vars.add(hash_expr)
         return modified_vars
+
+    def _get_instance_in_context(self, name: str):
+        return self.__global_ctx.get(name)

--- a/src/taipy/gui/utils/types.py
+++ b/src/taipy/gui/utils/types.py
@@ -172,6 +172,12 @@ class _TaipyContentImage(_TaipyBase):
         return _TaipyBase._HOLDER_PREFIX + "Ci"
 
 
+class _TaipyContentHtml(_TaipyBase):
+    @staticmethod
+    def get_hash():
+        return _TaipyBase._HOLDER_PREFIX + "Ch"
+
+
 class _TaipyDict(_TaipyBase):
     def get(self):
         val = super().get()

--- a/src/taipy/gui/viselements.json
+++ b/src/taipy/gui/viselements.json
@@ -1187,7 +1187,7 @@
           {
             "name": "content",
             "type": "dynamic(any)",
-            "doc": "The content provided to the part. cf. documentation on content providers."
+            "doc": "The content provided to the part. See the documentation section on content providers."
           }
         ]
       }

--- a/src/taipy/gui/viselements.json
+++ b/src/taipy/gui/viselements.json
@@ -1183,6 +1183,11 @@
             "name": "height",
             "type": "dynamic(str)",
             "doc": "The height, in CSS units, of this block."
+          },
+          {
+            "name": "content",
+            "type": "dynamic(any)",
+            "doc": "The content provided to the part. cf. documentation on content providers."
           }
         ]
       }


### PR DESCRIPTION
Addresses the generic part of [taipy#444](https://github.com/Avaiga/taipy/issues/444).

The user can create *content provider* functions that, depending on a content type (set to the *content* property of a `part`), converts it into HTML code that Taipy can integrate in a page.

A provider would be declared as :

```python
from taipy.gui import Gui

from plotly.graph_objs import Figure

Gui.register_content_provider(Figure, get_figure_html)

def get_figure_html(figure: Figure):
    return figure.to_html()

```

Then using the provider is as simple as

```
import plotly.express as px

md = """
# Taipy Plotly Provider

<|part|content={px.scatter(df, x="sepal_length", y="sepal_width", color="species")}|>

"""

Gui(md).run()

```