### PR TITLE
Adding comments to Taipy pages definition

### DIFF
--- a/src/taipy/gui/_comment.py
+++ b/src/taipy/gui/_comment.py
@@ -1,104 +1,64 @@
 """
-This initial text  must be removed and placed in the Taipy documentetion:
+This Python file contains two routines that enable the use of comments in Taipy pages using Markdown codes. It supports two types of comments:
+ A- Line-ending comment (/#): Should be used at the end of a line or on a standalone line. Everything after /# will be removed.
+ B- Inserted comment (/* ... */): Can be used within the code. Only the text within /* ... */ will be removed.
 
-This Python file contain two rotines that allow the use of comentes in Taipy peges
-that using Markdown codes. 
-For HTML codes the comments are made using /*    */ delimiters, for Markdown
-we define the same but incliding the use of a like python comment given by /# delimiter
+Example usage in Taipy pages definition:
 
-Two types of comments are allowed inside of the string that define the page Markdown code::
-	 A- Line-ending comment: /# XXXX  =>  Need be used in the end of the line or in a complete line.
-	                                                                    All words before /# will be removed  
-	 B- Comment inserted: /* XXXX  */    =>  Can be used inside the code. 
-	                                                                    Only the text  /* XXXX  */   will be removed
-
-Example of the new use comments in Taipe pages definition:
-
-page_login ='''''' 
-/* The Taipy page begining  here,  to get 3 new lines use \n to do this:*/  \n\n\n
-/# In the line below the msg1[1] contain "Username or Email"
-/#presented in 8 idions:   
-
-/# "Username or Email" message,  in 8 idions:
-<|{msg1[Idioma_sel.id /*number of selected idiom =1 to 8 */]}|text|raw|>\n
-
-/#This Markdown get  the user name
+Original Page with Comments:
+---------------------------
+page_login = '''
+/* Page starts here and two new lines will be include:*/ \n\n
+/# This line will be removed and this 3 new lines not has efect: \n\n\n 
+/# ''Username or Email'' message in various languages:
+<|{msg1[Idioma_sel.id/* idiom number from 0 to 7*/]}|text|raw|>
+\n /# This new line will be usede because '\n' is place berore of '/#'
+/* These lines of code was disabled for  purpose of testing 
+/#This Markdown get  the user name:
 <|{UserName}|input|> \n 
-
-/# "Inform Password" message, in 8 idions:
-<|{msg2[Idioma_sel.id]/* Password */}|text|raw|>:\n
-
 /#This Markdown get  the Password:
-<|{PassWord}|input|> \n 
-/# We need a way to hide the letters
-/# when the user enters this value!
+<|{PassWord}|input|> \n
+ */
+ \n
+'''
 
-/#This Markdown creat a Login button: 
-<|msg3[Idioma_sel.id+1]/*button caption: "Login" in 8 idions */}|button|active|
-on_action=confirma_login /* python rotine that react to the button press action*/|>\n
-/# We need define a rotine in python to use this UserName and PassWord values:
-/# def  confirma_login(state):
-/#      print("nome User=",state.UserName ); 
-/#      print("senha=",state.PassWord ); 
+Processed Page without Comments:
+--------------------------------
 
-/* The Taipy page finish here, with this  3'', the use of new line is optional */ \n 
-''''''
-
-The same page with  Markdown code, affer the comments be removed:
-
-page_login ='''''' 
-\n\n\n
-
+page_login = '''
+\n
 <|{msg1[Idioma_sel.id]}|text|raw|>\n
+\n
+\n
+'''
+Note: Removing comments results in cleaner code but may reduce understandability regarding 
+message variables and function names.
 
-<|{UserName}|input|> \n 
-
-<|{msg2[Idioma_sel.id]}|text|raw|>:\n
-
-<|{PassWord}|input|> \n 
-
-<|msg3[Idioma_sel.id+1]}|
-button|active|on_action=confirma_login|>\n
-
-''''''
-Observation: Whitout comment is a more clean code, but hard to undstand 
-this msg1 to msg3 meaning, and the Idioma_sel use,  and that 
-confirma_login is a pythoc rotine name...
+Design by Dr. Policarpo Yoshin Ulianov
+Powered by ChatGPT 4 
+Please remove the text above and put it in Taipy docs  if this improvment was aproved
 """
-
-#Here is the real  beginning of _comment.py
+# Beginning of _comment.py
 
 import re
 
-#The function remove_commen allows User to do comments in Markdown codes in order to 
-#facilitate understanding and documentation of what was developed.
-#Everything after /# until the end of the line will be removed.
-#Only the part that falls within the delimiters (/* */) will be removed.
-
 def remove_comment(string):
-    # Remove /* ... */ comments
-    string = re.sub(r'/\*.*?\*/', '', string)
-    # Remove entire lines starting with /#
+    """
+    Remove comments from Markdown strings.
+    - /* ... */: Removes multiline comments.
+    - /#: Removes everything after /# till the end of the line. 
+    If a line starts with /#, the whole line is removed.
+    """
+    string = re.sub(r'/\*.*?\*/', '', string, flags=re.DOTALL)
+    
     lines = string.split('\n')
-    cleaned_lines = [line for line in lines if not line.strip().startswith('/#')]
+    cleaned_lines = [line.split('/#')[0] if '/#' in line else line for line in lines if not line.strip().startswith('/#')]
     return '\n'.join(cleaned_lines)
 
-# this funcition remove the commente of a pages_dict like:
-#  pages = {
-#     "/": pg_root,
-#     "home": pg_home,
-#     "login": pg_login,     
-#     "about": pg_about
-#     }
-#
-# The pages are get one by one and apply remove_comment function
-# When user call Gui(page=page).run() the fist sptep inside
-# Gui.run is do  page = remove_comment_from_pages(page)
-# so for the Taipy code interpreter It's as if none of these comments existed. 
-
 def remove_comment_from_pages(pages_dict):
-    #print("remov comments")
-    for key, value in pages_dict.items():
-        pages_dict[key] = remove_comment(value)
-    return pages_dict
+    """
+    Apply remove_comment to each page in a dictionary of pages.
+    This function is typically called before rendering the pages in Taipy, ensuring that comments by do not appear in the final output.
+    """
+    return {key: remove_comment(value) for key, value in pages_dict.items()}
 

--- a/src/taipy/gui/_comment.py
+++ b/src/taipy/gui/_comment.py
@@ -1,0 +1,104 @@
+"""
+This initial text  must be removed and placed in the Taipy documentetion:
+
+This Python file contain two rotines that allow the use of comentes in Taipy peges
+that using Markdown codes. 
+For HTML codes the comments are made using /*    */ delimiters, for Markdown
+we define the same but incliding the use of a like python comment given by /# delimiter
+
+Two types of comments are allowed inside of the string that define the page Markdown code::
+	 A- Line-ending comment: /# XXXX  =>  Need be used in the end of the line or in a complete line.
+	                                                                    All words before /# will be removed  
+	 B- Comment inserted: /* XXXX  */    =>  Can be used inside the code. 
+	                                                                    Only the text  /* XXXX  */   will be removed
+
+Example of the new use comments in Taipe pages definition:
+
+page_login ='''''' 
+/* The Taipy page begining  here,  to get 3 new lines use \n to do this:*/  \n\n\n
+/# In the line below the msg1[1] contain "Username or Email"
+/#presented in 8 idions:   
+
+/# "Username or Email" message,  in 8 idions:
+<|{msg1[Idioma_sel.id /*number of selected idiom =1 to 8 */]}|text|raw|>\n
+
+/#This Markdown get  the user name
+<|{UserName}|input|> \n 
+
+/# "Inform Password" message, in 8 idions:
+<|{msg2[Idioma_sel.id]/* Password */}|text|raw|>:\n
+
+/#This Markdown get  the Password:
+<|{PassWord}|input|> \n 
+/# We need a way to hide the letters
+/# when the user enters this value!
+
+/#This Markdown creat a Login button: 
+<|msg3[Idioma_sel.id+1]/*button caption: "Login" in 8 idions */}|button|active|
+on_action=confirma_login /* python rotine that react to the button press action*/|>\n
+/# We need define a rotine in python to use this UserName and PassWord values:
+/# def  confirma_login(state):
+/#      print("nome User=",state.UserName ); 
+/#      print("senha=",state.PassWord ); 
+
+/* The Taipy page finish here, with this  3'', the use of new line is optional */ \n 
+''''''
+
+The same page with  Markdown code, affer the comments be removed:
+
+page_login ='''''' 
+\n\n\n
+
+<|{msg1[Idioma_sel.id]}|text|raw|>\n
+
+<|{UserName}|input|> \n 
+
+<|{msg2[Idioma_sel.id]}|text|raw|>:\n
+
+<|{PassWord}|input|> \n 
+
+<|msg3[Idioma_sel.id+1]}|
+button|active|on_action=confirma_login|>\n
+
+''''''
+Observation: Whitout comment is a more clean code, but hard to undstand 
+this msg1 to msg3 meaning, and the Idioma_sel use,  and that 
+confirma_login is a pythoc rotine name...
+"""
+
+#Here is the real  beginning of _comment.py
+
+import re
+
+#The function remove_commen allows User to do comments in Markdown codes in order to 
+#facilitate understanding and documentation of what was developed.
+#Everything after /# until the end of the line will be removed.
+#Only the part that falls within the delimiters (/* */) will be removed.
+
+def remove_comment(string):
+    # Remove /* ... */ comments
+    string = re.sub(r'/\*.*?\*/', '', string)
+    # Remove entire lines starting with /#
+    lines = string.split('\n')
+    cleaned_lines = [line for line in lines if not line.strip().startswith('/#')]
+    return '\n'.join(cleaned_lines)
+
+# this funcition remove the commente of a pages_dict like:
+#  pages = {
+#     "/": pg_root,
+#     "home": pg_home,
+#     "login": pg_login,     
+#     "about": pg_about
+#     }
+#
+# The pages are get one by one and apply remove_comment function
+# When user call Gui(page=page).run() the fist sptep inside
+# Gui.run is do  page = remove_comment_from_pages(page)
+# so for the Taipy code interpreter It's as if none of these comments existed. 
+
+def remove_comment_from_pages(pages_dict):
+    #print("remov comments")
+    for key, value in pages_dict.items():
+        pages_dict[key] = remove_comment(value)
+    return pages_dict
+

--- a/src/taipy/gui/gui.py
+++ b/src/taipy/gui/gui.py
@@ -35,6 +35,7 @@ from flask import Blueprint, Flask, g, jsonify, request, send_file, send_from_di
 from werkzeug.utils import secure_filename
 
 from taipy.logger._taipy_logger import _TaipyLogger
+from _comment import remove_comment_from_pages,remove_comment 
 
 if util.find_spec("pyngrok"):
     from pyngrok import ngrok
@@ -287,6 +288,15 @@ class Gui:
                 as the underlying server. If omitted or set to None, this `Gui` will create its
                 own Flask application instance and use it to serve the pages.
         """
+        # 1st steep: remove pages comment /* XXX */ and /# XXX YYY
+        if isinstance(pages, str):
+            #print("Single page case")
+            page1 = remove_comment(pages)
+            pages = {"/": page1}
+        else:
+            #print("Multiple pages case")
+            pages= remove_comment_from_pages(pages)
+   
         # store suspected local containing frame
         self.__frame = t.cast(FrameType, t.cast(FrameType, inspect.currentframe()).f_back)
         self.__default_module_name = _get_module_name_from_frame(self.__frame)


### PR DESCRIPTION
The included _comment.py python file contain two rotins that allow the use of comentes in Taipy pages strings  that using Markdown codes. 
For HTML codes the comments are made using / *    * / delimiters, for Markdown
we define the same but including the use of a like python comment given by "/#" delimiter
Two types of comments are allowed inside of the string that define the page Markdown code::
A- Line-ending comment: /# XXXX  =>  Need be used in the end of the line or in a complete line. All words before /# will be removed  
B- Comment inserted: / * XXXX  * /    =>  Can be used inside the code. 	                                                                    Only the text  / * XXXX  * /   will be removed

Example of the new use comments in Taipe pages definition:

page_login ="""
/ * The Taipy page beginning  here,  to get 3 new lines use \n to do this:* /  \n\n\n
/# In the line below the msg1[1] contain "Username or Email"
/#presented in 8 idioms:   
/#
/# "Username or Email" message,  in 8 idioms:
<|{msg1[Idioma_sel.id / *number of selected idiom =1 to 8 * /]}|text|raw|>\n
/#
/#This Markdown get  the user name
<|{UserName}|input|> \n 
/#
/# "Inform Password" message, in 8 idions:
<|{msg2[Idioma_sel.id]/* Password */}|text|raw|>:\n
/#
/#This Markdown get  the Password:
<|{PassWord}|input|> \n 
/# We need a way to hide the letters
/# when the user enters this value!
/#
/#This Markdown creat a Login button: 
<|msg3[Idioma_sel.id+1]/ *button caption: "Login" in 8 idioMs * /}|button|active|
on_action=confirma_login / * python rotine that react to the button press action* /|>\n
/# We need define a rotine in python to use this UserName and PassWord values:
/# def  confirma_login(state):
/#      print("nome User=",state.UserName ); 
/#      print("senha=",state.PassWord ); 
/#
/ * The Taipy page finish here, with this  3'', the use of new line is optional * / \n 
"""
OBS: I use /"space"*  because /* and */  (/"no-space"*  and   *"no-space"/ ) is given problem in it chat...
 
The same page with  Markdown code, after the comments be removed:

page_login =""" 
\n\n\n
<|{msg1[Idioma_sel.id]}|text|raw|>\n
<|{UserName}|input|> \n 
<|{msg2[Idioma_sel.id]}|text|raw|>:\n
<|{PassWord}|input|> \n 
<|msg3[Idioma_sel.id+1]}|
button|active|on_action=confirma_login|>\n
"""
Observation: Whiteout comment is a more clean code, but hard to undusted 
this msg1 to msg3 meaning, and the Idioma_sel use,  and that 
confirma_login is a python function name....
Another benefit of this scheme is the possibility of disabling parts of the code for testing purposes.

I believe this is a very positive feature and nothing is lost with it, with the fact that you can post comments and can easy disabling code parts whitout lost of information. 
If the user don't want comments, he  just don't use it...
Now, if this improvement is accepted, it is necessary to modify the documentation to show this new possibility of making comments in Taipy.
I can help do this if necessary....
Best Regards
Dr. Policarpo Yoshin Ulianov.
poliyu77@gmail.com
PS: I did basic tests with about 15 types of pages on Linux Debian 11 and Windows 10, with Python 3.11 and this scheme worked well. I believe it shouldn't cause any problems as it's a very simple routine that just removes comments, but it would be interesting for you to test it a little better.

